### PR TITLE
Experiment expr intersect

### DIFF
--- a/src/expr-library/comparison/between.ts
+++ b/src/expr-library/comparison/between.ts
@@ -1,0 +1,14 @@
+import {makeTernaryComparison, TernaryComparison} from "../factory";
+import {OperatorType} from "../../operator-type";
+
+/**
+ * https://dev.mysql.com/doc/refman/8.0/en/comparison-operators.html#operator_between
+ *
+ * This version of the `BETWEEN ... AND` operator prevents `NULL`.
+ *
+ * For null-safe checks, @see {@link nullSafeBetween}
+ *
+ */
+export const between : TernaryComparison = makeTernaryComparison(
+    OperatorType.BETWEEN_AND
+);

--- a/src/expr-library/comparison/index.ts
+++ b/src/expr-library/comparison/index.ts
@@ -1,3 +1,4 @@
+export * from "./between";
 export * from "./coalesce";
 export * from "./eq-primary-key";
 export * from "./eq";
@@ -6,3 +7,4 @@ export * from "./gt";
 export * from "./lt-eq";
 export * from "./lt";
 export * from "./not-eq";
+export * from "./not-between";

--- a/src/expr-library/comparison/not-between.ts
+++ b/src/expr-library/comparison/not-between.ts
@@ -1,0 +1,14 @@
+import {makeTernaryComparison, TernaryComparison} from "../factory";
+import {OperatorType} from "../../operator-type";
+
+/**
+ * https://dev.mysql.com/doc/refman/8.0/en/comparison-operators.html#operator_not-between
+ *
+ * This version of the `NOT BETWEEN ... AND` operator prevents `NULL`.
+ *
+ * For null-safe checks, @see {@link nullSafeNotBetween}
+ *
+ */
+export const notBetween : TernaryComparison = makeTernaryComparison(
+    OperatorType.NOT_BETWEEN_AND
+);

--- a/src/expr-library/factory/index.ts
+++ b/src/expr-library/factory/index.ts
@@ -7,4 +7,5 @@ export * from "./make-idempotent-unary-operator";
 export * from "./make-null-safe-comparison";
 export * from "./make-null-safe-unary-comparison";
 export * from "./make-nullary-operator";
+export * from "./make-ternary-comparison";
 export * from "./make-unary-operator";

--- a/src/expr-library/factory/make-binary-operator.ts
+++ b/src/expr-library/factory/make-binary-operator.ts
@@ -79,7 +79,7 @@ export function makeBinaryOperator<
     ) : (
         ExprUtil.Intersect<OutputTypeT, LeftT|RightT>
     ) => {
-        return ExprUtil.intersect(
+        return ExprUtil.intersect<OutputTypeT, LeftT|RightT>(
             mapper,
             [left, right],
             OperatorNodeUtil.operatorNode2<OperatorTypeT>(

--- a/src/expr-library/factory/make-binary-operator.ts
+++ b/src/expr-library/factory/make-binary-operator.ts
@@ -1,6 +1,6 @@
 import * as tm from "type-mapping";
 import {RawExpr, RawExprUtil} from "../../raw-expr";
-import {Expr, expr} from "../../expr";
+import {ExprUtil} from "../../expr";
 import {OperatorNodeUtil} from "../../ast";
 import {OperatorType} from "../../operator-type";
 import {TypeHint} from "../../type-hint";
@@ -16,13 +16,7 @@ export type BinaryOperator<
         left : LeftT,
         right : RightT
     ) => (
-        Expr<{
-            mapper : tm.SafeMapper<OutputTypeT>,
-            usedRef : RawExprUtil.IntersectUsedRef<
-                | LeftT
-                | RightT
-            >,
-        }>
+        ExprUtil.Intersect<OutputTypeT, LeftT|RightT>
     )
 ;
 export type BinaryOperator2<
@@ -37,13 +31,7 @@ export type BinaryOperator2<
         left : LeftT,
         right : RightT
     ) => (
-        Expr<{
-            mapper : tm.SafeMapper<OutputTypeT>,
-            usedRef : RawExprUtil.IntersectUsedRef<
-                | LeftT
-                | RightT
-            >,
-        }>
+        ExprUtil.Intersect<OutputTypeT, LeftT|RightT>
     )
 ;
 export function makeBinaryOperator<
@@ -89,22 +77,11 @@ export function makeBinaryOperator<
         left : LeftT,
         right : RightT
     ) : (
-        Expr<{
-            mapper : tm.SafeMapper<OutputTypeT>,
-            usedRef : RawExprUtil.IntersectUsedRef<
-                | LeftT
-                | RightT
-            >,
-        }>
+        ExprUtil.Intersect<OutputTypeT, LeftT|RightT>
     ) => {
-        return expr(
-            {
-                mapper,
-                usedRef : RawExprUtil.intersectUsedRef(
-                    left,
-                    right
-                ),
-            },
+        return ExprUtil.intersect(
+            mapper,
+            [left, right],
             OperatorNodeUtil.operatorNode2<OperatorTypeT>(
                 operatorType,
                 [

--- a/src/expr-library/factory/make-chainable-decimal-operator.ts
+++ b/src/expr-library/factory/make-chainable-decimal-operator.ts
@@ -1,6 +1,6 @@
 import * as tm from "type-mapping";
 import {RawExpr, RawExprUtil, AnyRawExpr} from "../../raw-expr";
-import {ExprUtil, expr} from "../../expr";
+import {ExprUtil} from "../../expr";
 import {
     Ast,
     AstArray,
@@ -89,7 +89,7 @@ export function makeChainableDecimalOperator<
     const result : ChainableDecimalOperator = <ArrT extends RawExpr<Decimal>[]> (
         ...arr : ArrT
     ) : (
-        ChainableDecimalOperatorReturn<ArrT>
+        ExprUtil.Intersect<Decimal, ArrT[number]>
     ) => {
         if (identityAst == undefined) {
             const newIdentityAst = LiteralValueNodeUtil.decimalLiteralNode(identityElement, 65, 30);
@@ -98,7 +98,6 @@ export function makeChainableDecimalOperator<
             }
             identityAst = newIdentityAst;
         }
-        const usedRef = RawExprUtil.intersectUsedRef(...arr);
         let operands : [Ast, ...Ast[]]|undefined = undefined;
 
         for (const rawExpr of arr) {
@@ -127,11 +126,9 @@ export function makeChainableDecimalOperator<
                 }
             }
         }
-        return expr(
-            {
-                mapper,
-                usedRef,
-            },
+        return ExprUtil.intersect<Decimal, ArrT[number]>(
+            mapper,
+            arr,
             (
                 (operands == undefined) ?
                 /**
@@ -149,7 +146,7 @@ export function makeChainableDecimalOperator<
                     typeHint
                 )
             )
-        ) as ChainableDecimalOperatorReturn<ArrT>;
+        );
     };
 
     return result;

--- a/src/expr-library/factory/make-chainable-decimal-operator.ts
+++ b/src/expr-library/factory/make-chainable-decimal-operator.ts
@@ -1,14 +1,12 @@
 import * as tm from "type-mapping";
 import {RawExpr, RawExprUtil, AnyRawExpr} from "../../raw-expr";
-import {IExpr, Expr, ExprUtil, expr} from "../../expr";
+import {ExprUtil, expr} from "../../expr";
 import {
     Ast,
     AstArray,
     OperatorNodeUtil,
     AstUtil,
 } from "../../ast";
-import {TryReuseExistingType} from "../../type-util";
-import {IExprSelectItem} from "../../expr-select-item";
 import {OperatorType} from "../../operator-type";
 import {LiteralValueNodeUtil, LiteralValueNode} from "../../ast/literal-value-node";
 import {PrimitiveExprUtil} from "../../primitive-expr";
@@ -63,16 +61,7 @@ export type ChainableDecimalOperatorReturn<
         usedRef : RawExprUtil.IntersectUsedRef<ArrT[number]>,
     }>
     */
-    TryReuseExistingType<
-        ArrT[number],
-        Expr<{
-            mapper : tm.SafeMapper<Decimal>,
-            usedRef : TryReuseExistingType<
-                Extract<ArrT[number], IExpr|IExprSelectItem>["usedRef"],
-                RawExprUtil.IntersectUsedRef<ArrT[number]>
-            >,
-        }>
-    >
+    ExprUtil.Intersect<Decimal, ArrT[number]>
 ;
 export type ChainableDecimalOperator =
     <ArrT extends RawExpr<Decimal>[]> (

--- a/src/expr-library/factory/make-chainable-operator.ts
+++ b/src/expr-library/factory/make-chainable-operator.ts
@@ -1,14 +1,12 @@
 import * as tm from "type-mapping";
 import {RawExpr, RawExprUtil, AnyRawExpr} from "../../raw-expr";
-import {IExpr, Expr, ExprUtil, expr} from "../../expr";
+import {ExprUtil} from "../../expr";
 import {
     Ast,
     AstArray,
     OperatorNodeUtil,
     AstUtil,
 } from "../../ast";
-import {TryReuseExistingType} from "../../type-util";
-import {IExprSelectItem} from "../../expr-select-item";
 import {OperatorType} from "../../operator-type";
 import {LiteralValueNodeUtil, LiteralValueNode} from "../../ast/literal-value-node";
 import {PrimitiveExprUtil} from "../../primitive-expr";
@@ -60,6 +58,7 @@ export type ChainableOperatorReturn<
         usedRef : RawExprUtil.IntersectUsedRef<ArrT[number]>,
     }>
     */
+    /*
     TryReuseExistingType<
         ArrT[number],
         Expr<{
@@ -69,6 +68,11 @@ export type ChainableOperatorReturn<
                 RawExprUtil.IntersectUsedRef<ArrT[number]>
             >,
         }>
+    >
+    */
+    ExprUtil.Intersect<
+        TypeT,
+        ArrT[number]
     >
 ;
 export type ChainableOperator<TypeT extends null|boolean|number|bigint|string|Buffer> =
@@ -94,7 +98,10 @@ export function makeChainableOperator<
     const result : ChainableOperator<TypeT> = <ArrT extends RawExpr<TypeT>[]> (
         ...arr : ArrT
     ) : (
-        ChainableOperatorReturn<TypeT, ArrT>
+        ExprUtil.Intersect<
+            TypeT,
+            ArrT[number]
+        >
     ) => {
         if (identityAst == undefined) {
             const newIdentityAst = RawExprUtil.buildAst(identityElement);
@@ -103,7 +110,6 @@ export function makeChainableOperator<
             }
             identityAst = newIdentityAst;
         }
-        const usedRef = RawExprUtil.intersectUsedRef(...arr);
         let operands : [Ast, ...Ast[]]|undefined = undefined;
 
         for (const rawExpr of arr) {
@@ -132,11 +138,9 @@ export function makeChainableOperator<
                 }
             }
         }
-        return expr(
-            {
-                mapper,
-                usedRef,
-            },
+        return ExprUtil.intersect(
+            mapper,
+            arr,
             (
                 (operands == undefined) ?
                 /**
@@ -154,7 +158,7 @@ export function makeChainableOperator<
                     typeHint
                 )
             )
-        ) as ChainableOperatorReturn<TypeT, ArrT>;
+        ) as any;
     };
 
     return result;

--- a/src/expr-library/factory/make-chainable-operator.ts
+++ b/src/expr-library/factory/make-chainable-operator.ts
@@ -138,7 +138,7 @@ export function makeChainableOperator<
                 }
             }
         }
-        return ExprUtil.intersect(
+        return ExprUtil.intersect<TypeT, ArrT[number]>(
             mapper,
             arr,
             (

--- a/src/expr-library/factory/make-comparison.ts
+++ b/src/expr-library/factory/make-comparison.ts
@@ -51,7 +51,7 @@ export function makeComparison<OperatorTypeT extends OperatorType> (
     ) => {
         RawExprUtil.assertNonNull("LHS", left);
         RawExprUtil.assertNonNull("RHS", left);
-        return ExprUtil.intersect(
+        return ExprUtil.intersect<boolean, LeftT|RightT>(
             tm.mysql.boolean(),
             [left, right],
             OperatorNodeUtil.operatorNode2<OperatorTypeT>(

--- a/src/expr-library/factory/make-double-elimination-unary-operator.ts
+++ b/src/expr-library/factory/make-double-elimination-unary-operator.ts
@@ -29,7 +29,7 @@ export function makeDoubleEliminationUnaryOperator<
     ) : (
         ExprUtil.Intersect<OutputTypeT, ArgT>
     ) => {
-        return ExprUtil.intersect(
+        return ExprUtil.intersect<OutputTypeT, ArgT>(
             mapper,
             [arg],
             tryExtractAstOr(

--- a/src/expr-library/factory/make-double-elimination-unary-operator.ts
+++ b/src/expr-library/factory/make-double-elimination-unary-operator.ts
@@ -1,6 +1,6 @@
 import * as tm from "type-mapping";
 import {RawExpr, RawExprUtil} from "../../raw-expr";
-import {Expr, expr} from "../../expr";
+import {ExprUtil} from "../../expr";
 import {OperatorNodeUtil} from "../../ast";
 import {UnaryOperator} from "./make-unary-operator";
 import {tryExtractAstOr} from "../../ast/util";
@@ -27,16 +27,11 @@ export function makeDoubleEliminationUnaryOperator<
     > (
         arg : ArgT
     ) : (
-        Expr<{
-            mapper : tm.SafeMapper<OutputTypeT>,
-            usedRef : RawExprUtil.UsedRef<ArgT>,
-        }>
+        ExprUtil.Intersect<OutputTypeT, ArgT>
     ) => {
-        return expr(
-            {
-                mapper,
-                usedRef : RawExprUtil.usedRef(arg),
-            },
+        return ExprUtil.intersect(
+            mapper,
+            [arg],
             tryExtractAstOr(
                 RawExprUtil.buildAst(arg),
                 operand => (

--- a/src/expr-library/factory/make-idempotent-unary-operator.ts
+++ b/src/expr-library/factory/make-idempotent-unary-operator.ts
@@ -1,6 +1,6 @@
 import * as tm from "type-mapping";
 import {RawExpr, RawExprUtil} from "../../raw-expr";
-import {Expr, expr} from "../../expr";
+import {ExprUtil} from "../../expr";
 import {OperatorNodeUtil} from "../../ast";
 import {UnaryOperator} from "./make-unary-operator";
 import {tryExtractAstOr} from "../../ast/util";
@@ -27,16 +27,11 @@ export function makeIdempotentUnaryOperator<
     > (
         arg : ArgT
     ) : (
-        Expr<{
-            mapper : tm.SafeMapper<OutputTypeT>,
-            usedRef : RawExprUtil.UsedRef<ArgT>,
-        }>
+        ExprUtil.Intersect<OutputTypeT, ArgT>
     ) => {
-        return expr(
-            {
-                mapper,
-                usedRef : RawExprUtil.usedRef(arg),
-            },
+        return ExprUtil.intersect(
+            mapper,
+            [arg],
             tryExtractAstOr(
                 RawExprUtil.buildAst(arg),
                 operand => OperatorNodeUtil.isOperatorNode(operand) && operand.operatorType == operatorType,

--- a/src/expr-library/factory/make-idempotent-unary-operator.ts
+++ b/src/expr-library/factory/make-idempotent-unary-operator.ts
@@ -29,7 +29,7 @@ export function makeIdempotentUnaryOperator<
     ) : (
         ExprUtil.Intersect<OutputTypeT, ArgT>
     ) => {
-        return ExprUtil.intersect(
+        return ExprUtil.intersect<OutputTypeT, ArgT>(
             mapper,
             [arg],
             tryExtractAstOr(

--- a/src/expr-library/factory/make-null-safe-comparison.ts
+++ b/src/expr-library/factory/make-null-safe-comparison.ts
@@ -27,8 +27,16 @@ export function makeNullSafeComparison<OperatorTypeT extends OperatorType> (
     operatorType : OperatorTypeT & OperatorNodeUtil.AssertHasOperand2<OperatorTypeT>,
     typeHint? : TypeHint
 ) : NullSafeComparison {
-    const result : NullSafeComparison = (left, right) => {
-        return ExprUtil.intersect(
+    const result : NullSafeComparison = <
+        LeftT extends RawExpr<PrimitiveExpr>,
+        RightT extends RawExpr<RawExprUtil.TypeOf<LeftT>|null>
+    >(
+        left : LeftT,
+        right : RightT
+    ) : (
+        ExprUtil.Intersect<boolean, LeftT|RightT>
+    ) => {
+        return ExprUtil.intersect<boolean, LeftT|RightT>(
             tm.mysql.boolean(),
             [left, right],
             OperatorNodeUtil.operatorNode2<OperatorTypeT>(

--- a/src/expr-library/factory/make-null-safe-comparison.ts
+++ b/src/expr-library/factory/make-null-safe-comparison.ts
@@ -1,5 +1,5 @@
 import * as tm from "type-mapping";
-import {Expr, expr} from "../../expr";
+import {ExprUtil} from "../../expr";
 import {RawExpr} from "../../raw-expr";
 import {PrimitiveExpr} from "../../primitive-expr";
 import {RawExprUtil} from "../../raw-expr";
@@ -15,13 +15,7 @@ export type NullSafeComparison = (
         left : LeftT,
         right : RightT
     ) => (
-        Expr<{
-            mapper : tm.SafeMapper<boolean>,
-            usedRef : RawExprUtil.IntersectUsedRef<
-                | LeftT
-                | RightT
-            >,
-        }>
+        ExprUtil.Intersect<boolean, LeftT|RightT>
     )
 );
 /**
@@ -34,14 +28,9 @@ export function makeNullSafeComparison<OperatorTypeT extends OperatorType> (
     typeHint? : TypeHint
 ) : NullSafeComparison {
     const result : NullSafeComparison = (left, right) => {
-        return expr(
-            {
-                mapper : tm.mysql.boolean(),
-                usedRef : RawExprUtil.intersectUsedRef(
-                    left,
-                    right
-                ),
-            },
+        return ExprUtil.intersect(
+            tm.mysql.boolean(),
+            [left, right],
             OperatorNodeUtil.operatorNode2<OperatorTypeT>(
                 operatorType,
                 [

--- a/src/expr-library/factory/make-null-safe-unary-comparison.ts
+++ b/src/expr-library/factory/make-null-safe-unary-comparison.ts
@@ -1,13 +1,27 @@
 import * as tm from "type-mapping";
-import {Expr, expr} from "../../expr";
+import {ExprUtil} from "../../expr";
 import {RawExpr} from "../../raw-expr";
 import {PrimitiveExpr} from "../../primitive-expr";
 import {RawExprUtil} from "../../raw-expr";
 import {OperatorNodeUtil} from "../../ast";
 import {OperatorType} from "../../operator-type";
 import {TypeHint} from "../../type-hint";
+import {Expr} from "../../expr/expr-impl";
 
 export type NullSafeUnaryComparison = (
+    <
+        RawExprT extends RawExpr<PrimitiveExpr>
+    >(
+        rawExpr : RawExprT
+    ) => (
+        ExprUtil.Intersect<boolean, RawExprT>
+    )
+);
+/**
+ * Called wasteful because it does not attempt to reuse existing types,
+ * wasting our depth limit.
+ */
+export type __WastefulNullSafeUnaryComparison = (
     <
         RawExprT extends RawExpr<PrimitiveExpr>
     >(
@@ -27,11 +41,9 @@ export function makeNullSafeUnaryComparison<OperatorTypeT extends OperatorType> 
     typeHint? : TypeHint
 ) : NullSafeUnaryComparison {
     const result : NullSafeUnaryComparison = (rawExpr) => {
-        return expr(
-            {
-                mapper : tm.mysql.boolean(),
-                usedRef : RawExprUtil.usedRef(rawExpr),
-            },
+        return ExprUtil.intersect(
+            tm.mysql.boolean(),
+            [rawExpr],
             OperatorNodeUtil.operatorNode1<OperatorTypeT>(
                 operatorType,
                 [

--- a/src/expr-library/factory/make-null-safe-unary-comparison.ts
+++ b/src/expr-library/factory/make-null-safe-unary-comparison.ts
@@ -40,7 +40,13 @@ export function makeNullSafeUnaryComparison<OperatorTypeT extends OperatorType> 
     operatorType : OperatorTypeT & OperatorNodeUtil.AssertHasOperand1<OperatorTypeT>,
     typeHint? : TypeHint
 ) : NullSafeUnaryComparison {
-    const result : NullSafeUnaryComparison = (rawExpr) => {
+    const result : NullSafeUnaryComparison = <
+        RawExprT extends RawExpr<PrimitiveExpr>
+    >(
+        rawExpr : RawExprT
+    ) : (
+        ExprUtil.Intersect<boolean, RawExprT>
+    ) => {
         return ExprUtil.intersect(
             tm.mysql.boolean(),
             [rawExpr],

--- a/src/expr-library/factory/make-operator-2-to-n.ts.todo
+++ b/src/expr-library/factory/make-operator-2-to-n.ts.todo
@@ -1,0 +1,102 @@
+import * as tm from "type-mapping";
+import {RawExpr, RawExprUtil, AnyRawExpr} from "../../raw-expr";
+import {Expr, expr} from "../../expr";
+import {OperatorNodeUtil} from "../../ast";
+import {OperatorType} from "../../operator-type";
+import {TypeHint} from "../../type-hint";
+import {TryReuseExistingType} from "../../type-util";
+import {IExpr} from "../../expr/expr";
+import {IExprSelectItem} from "../../expr-select-item";
+
+export type Operator2ToNReturn<
+    InputTypeT,
+    OutputTypeT,
+    Arg0T extends RawExpr<InputTypeT>,
+    Arg1T extends RawExpr<InputTypeT>,
+    ArgsT extends readonly RawExpr<InputTypeT>[]
+> =
+    TryReuseExistingType<
+        Arg0T|Arg1T|ArgsT[number],
+        Expr<{
+            mapper : tm.SafeMapper<OutputTypeT>,
+            usedRef : TryReuseExistingType<
+                Extract<Arg0T|Arg1T|ArgsT[number], IExpr|IExprSelectItem>["usedRef"],
+                RawExprUtil.IntersectUsedRef<
+                    | Arg0T
+                    | Arg1T
+                    | ArgsT[number]
+                >
+            >,
+        }>
+    >
+;
+export type Operator2ToN<
+    InputTypeT,
+    OutputTypeT
+> =
+    <
+        Arg0T extends RawExpr<InputTypeT>,
+        Arg1T extends RawExpr<InputTypeT>,
+        ArgsT extends readonly RawExpr<InputTypeT>[]
+    > (
+        arg0 : Arg0T,
+        arg1 : Arg1T,
+        ...args : ArgsT
+    ) => (
+        Expr<{
+            mapper : tm.SafeMapper<OutputTypeT>,
+            usedRef : RawExprUtil.IntersectUsedRef<
+                | Arg0T
+                | Arg1T
+                | ArgsT[number]
+            >,
+        }>
+    )
+;
+export function makeBinaryOperator<
+    OperatorTypeT extends OperatorType,
+    InputTypeT,
+    OutputTypeT
+> (
+    operatorType : OperatorTypeT & OperatorNodeUtil.AssertHasOperand2<OperatorTypeT>,
+    mapper : tm.SafeMapper<OutputTypeT>,
+    typeHint? : TypeHint
+) : (
+    BinaryOperator<InputTypeT, OutputTypeT>
+) {
+    const result : BinaryOperator2<LeftTypeT, RightTypeT, OutputTypeT> = <
+        LeftT extends RawExpr<LeftTypeT>,
+        RightT extends RawExpr<RightTypeT>
+    > (
+        left : LeftT,
+        right : RightT
+    ) : (
+        Expr<{
+            mapper : tm.SafeMapper<OutputTypeT>,
+            usedRef : RawExprUtil.IntersectUsedRef<
+                | LeftT
+                | RightT
+            >,
+        }>
+    ) => {
+        return expr(
+            {
+                mapper,
+                usedRef : RawExprUtil.intersectUsedRef(
+                    left,
+                    right
+                ),
+            },
+            OperatorNodeUtil.operatorNode2<OperatorTypeT>(
+                operatorType,
+                [
+                    RawExprUtil.buildAst(left),
+                    RawExprUtil.buildAst(right),
+                ],
+                typeHint
+            )
+        );
+    };
+
+    return result;
+}

--- a/src/expr-library/factory/make-ternary-comparison.ts
+++ b/src/expr-library/factory/make-ternary-comparison.ts
@@ -7,18 +7,20 @@ import {OperatorNodeUtil} from "../../ast";
 import {OperatorType} from "../../operator-type";
 import {TypeHint} from "../../type-hint";
 
-export type ComparisonReturn<
+export type TernaryComparisonReturn<
     LeftT extends RawExpr<NonNullPrimitiveExpr>,
+    MidT extends RawExpr<PrimitiveExprUtil.NonNullPrimitiveType<RawExprUtil.TypeOf<LeftT>>>,
     RightT extends RawExpr<PrimitiveExprUtil.NonNullPrimitiveType<RawExprUtil.TypeOf<LeftT>>>
 > =
     ExprUtil.Intersect<
         boolean,
-        LeftT|RightT
+        LeftT|MidT|RightT
     >
 ;
-export type Comparison =
+export type TernaryComparison =
     <
         LeftT extends RawExpr<NonNullPrimitiveExpr>,
+        MidT extends RawExpr<PrimitiveExprUtil.NonNullPrimitiveType<RawExprUtil.TypeOf<LeftT>>>,
         /**
          * https://github.com/microsoft/TypeScript/issues/33002#issuecomment-523651736
          *
@@ -28,41 +30,48 @@ export type Comparison =
         RightT extends RawExpr<PrimitiveExprUtil.NonNullPrimitiveType<RawExprUtil.TypeOf<LeftT>>>
     >(
         left : LeftT,
+        mid : MidT,
         right : RightT
     ) => (
-        ComparisonReturn<LeftT, RightT>
+        TernaryComparisonReturn<LeftT, MidT, RightT>
     )
 ;
 
 /**
- * Factory for making comparison operators.
+ * Factory for making ternary comparison operators.
  *
  * These do not allow `null` to be used in comparisons.
  */
-export function makeComparison<OperatorTypeT extends OperatorType> (
-    operatorType : OperatorTypeT & OperatorNodeUtil.AssertHasOperand2<OperatorTypeT>,
+export function makeTernaryComparison<OperatorTypeT extends OperatorType> (
+    operatorType : OperatorTypeT & OperatorNodeUtil.AssertHasOperand3<OperatorTypeT>,
     typeHint? : TypeHint
-) : Comparison {
-    const result : Comparison = <
+) : TernaryComparison {
+    const result : TernaryComparison = <
         LeftT extends RawExpr<NonNullPrimitiveExpr>,
+        MidT extends RawExpr<PrimitiveExprUtil.NonNullPrimitiveType<RawExprUtil.TypeOf<LeftT>>>,
         RightT extends RawExpr<PrimitiveExprUtil.NonNullPrimitiveType<RawExprUtil.TypeOf<LeftT>>>
-    >(left : LeftT, right : RightT) : (
-        ComparisonReturn<LeftT, RightT>
+    >(left : LeftT, mid : MidT, right : RightT) : (
+        ExprUtil.Intersect<
+            boolean,
+            LeftT|MidT|RightT
+        >
     ) => {
         RawExprUtil.assertNonNull("LHS", left);
+        RawExprUtil.assertNonNull("MHS", mid);
         RawExprUtil.assertNonNull("RHS", left);
-        return ExprUtil.intersect(
+        return ExprUtil.intersect<boolean, LeftT|MidT|RightT>(
             tm.mysql.boolean(),
-            [left, right],
-            OperatorNodeUtil.operatorNode2<OperatorTypeT>(
+            [left, mid, right],
+            OperatorNodeUtil.operatorNode3<OperatorTypeT>(
                 operatorType,
                 [
                     RawExprUtil.buildAst(left),
+                    RawExprUtil.buildAst(mid),
                     RawExprUtil.buildAst(right),
                 ],
                 typeHint
             )
-        ) as ComparisonReturn<LeftT, RightT>;
+        );
     };
     return result;
 }

--- a/src/expr-library/factory/make-unary-operator.ts
+++ b/src/expr-library/factory/make-unary-operator.ts
@@ -1,6 +1,6 @@
 import * as tm from "type-mapping";
 import {RawExpr, RawExprUtil} from "../../raw-expr";
-import {Expr, expr} from "../../expr";
+import {ExprUtil} from "../../expr";
 import {OperatorNodeUtil} from "../../ast";
 import {OperatorType} from "../../operator-type";
 import {TypeHint} from "../../type-hint";
@@ -14,13 +14,7 @@ export type UnaryOperator<
     > (
         arg : ArgT
     ) => (
-        Expr<{
-            mapper : tm.SafeMapper<OutputTypeT>,
-            /**
-             * @todo Use `TryReuseExistingType<>` hack to fight off depth limit
-             */
-            usedRef : RawExprUtil.UsedRef<ArgT>,
-        }>
+        ExprUtil.Intersect<OutputTypeT, ArgT>
     )
 ;
 export function makeUnaryOperator<
@@ -37,16 +31,11 @@ export function makeUnaryOperator<
     > (
         arg : ArgT
     ) : (
-        Expr<{
-            mapper : tm.SafeMapper<OutputTypeT>,
-            usedRef : RawExprUtil.UsedRef<ArgT>,
-        }>
+        ExprUtil.Intersect<OutputTypeT, ArgT>
     ) => {
-        return expr(
-            {
-                mapper,
-                usedRef : RawExprUtil.usedRef(arg),
-            },
+        return ExprUtil.intersect<OutputTypeT, ArgT>(
+            mapper,
+            [arg],
             OperatorNodeUtil.operatorNode1<OperatorTypeT>(
                 operatorType,
                 [

--- a/src/expr/util/operation/index.ts
+++ b/src/expr/util/operation/index.ts
@@ -1,2 +1,3 @@
 export * from "./as";
+export * from "./intersect";
 export * from "./sort";

--- a/src/expr/util/operation/intersect.ts
+++ b/src/expr/util/operation/intersect.ts
@@ -1,0 +1,56 @@
+import * as tm from "type-mapping";
+import {AnyRawExpr, RawExprUtil} from "../../../raw-expr";
+import {Expr, expr} from "../../expr-impl";
+import {TryReuseExistingType} from "../../../type-util";
+import {IExpr} from "../../expr";
+import {IExprSelectItem} from "../../../expr-select-item";
+import {Ast} from "../../../ast";
+
+export type Intersect<
+    OutputTypeT,
+    ArgsT extends AnyRawExpr
+> =
+    TryReuseExistingType<
+        ArgsT,
+        Expr<{
+            mapper : tm.SafeMapper<OutputTypeT>,
+            usedRef : TryReuseExistingType<
+                Extract<ArgsT, IExpr|IExprSelectItem>["usedRef"],
+                RawExprUtil.IntersectUsedRef<
+                    ArgsT
+                >
+            >,
+        }>
+    >
+;
+/**
+ * Called wasteful because it does not attempt to reuse existing types,
+ * wasting our depth limit.
+ */
+export type __WastefulIntersect<
+    OutputTypeT,
+    ArgsT extends AnyRawExpr
+> =
+    Expr<{
+        mapper : tm.SafeMapper<OutputTypeT>,
+        usedRef : RawExprUtil.IntersectUsedRef<
+            ArgsT
+        >,
+    }>
+;
+export function intersect<
+    OutputTypeT,
+    ArgsT extends AnyRawExpr
+> (
+    mapper : tm.SafeMapper<OutputTypeT>,
+    args : ArgsT[],
+    ast : Ast
+) : Intersect<OutputTypeT, ArgsT> {
+    return expr(
+        {
+            mapper,
+            usedRef : RawExprUtil.intersectUsedRef(...args),
+        },
+        ast
+    ) as Intersect<OutputTypeT, ArgsT>;
+}

--- a/src/from-clause/util/operation/where-is-not-null.ts
+++ b/src/from-clause/util/operation/where-is-not-null.ts
@@ -7,6 +7,7 @@ import {WhereClause, WhereClauseUtil} from "../../../where-clause";
 import {ColumnRefUtil} from "../../../column-ref";
 import * as ExprLib from "../../../expr-library";
 import {ColumnIdentifierRefUtil} from "../../../column-identifier-ref";
+import {__WastefulNullSafeUnaryComparison} from "../../../expr-library";
 
 /**
  * https://github.com/microsoft/TypeScript/issues/32707#issuecomment-518347966
@@ -147,7 +148,7 @@ export function whereIsNotNull<
         whereClause : WhereClauseUtil.where(
             fromClause,
             whereClause,
-            () => ExprLib.isNotNull(column)
+            () => (ExprLib.isNotNull as __WastefulNullSafeUnaryComparison)(column)
         ),
     };
     return result;

--- a/src/from-clause/util/operation/where-is-null.ts
+++ b/src/from-clause/util/operation/where-is-null.ts
@@ -7,6 +7,7 @@ import {WhereClause, WhereClauseUtil} from "../../../where-clause";
 import {ColumnRefUtil} from "../../../column-ref";
 import * as ExprLib from "../../../expr-library";
 import {ColumnIdentifierRefUtil} from "../../../column-identifier-ref";
+import {__WastefulNullSafeUnaryComparison} from "../../../expr-library";
 
 /**
  * https://github.com/microsoft/TypeScript/issues/32707#issuecomment-518347966
@@ -147,7 +148,7 @@ export function whereIsNull<
         whereClause : WhereClauseUtil.where(
             fromClause,
             whereClause,
-            () => ExprLib.isNull(column)
+            () => (ExprLib.isNull as __WastefulNullSafeUnaryComparison)(column)
         ),
     };
     return result;

--- a/src/operator-type.ts
+++ b/src/operator-type.ts
@@ -99,8 +99,11 @@ export enum OperatorType {
      * -----
      *
      * + MySQL        : `GREATEST(x, y, ...)` //Requires 2 args
+     *   + `NULL` values cause return value of `NULL`
      * + PostgreSQL   : `GREATEST(x, ...)`    //Requires 1 arg
+     *   + Ignores `NULL` values
      * + SQLite       : `MAX(x, ...)`         //Requires 1 arg
+     *   + `NULL` values cause return value of `NULL`
      */
     GREATEST = "GREATEST",
 
@@ -395,7 +398,7 @@ export enum OperatorType {
         https://dev.mysql.com/doc/refman/8.0/en/logical-operators.html
     */
 
-   /**
+    /**
      * + https://dev.mysql.com/doc/refman/8.0/en/logical-operators.html#operator_and
      * + https://www.postgresql.org/docs/9.1/functions-logical.html
      * + https://www.sqlite.org/lang_expr.html#binaryops

--- a/test/compile-time/expected-output/expr-library/double/power/long-chain.d.ts
+++ b/test/compile-time/expected-output/expr-library/double/power/long-chain.d.ts
@@ -1,0 +1,37 @@
+import * as tm from "type-mapping/fluent";
+import * as tsql from "../../../../../../dist";
+export declare const expr: tsql.ExprImpl<tm.Mapper<unknown, number>, tsql.IUsedRef<{
+    readonly myTable: {
+        readonly someColumnA: number;
+        readonly someColumnB: number;
+        readonly someColumnC: number;
+    };
+}>>;
+export declare const expr2: tsql.ExprImpl<tm.Mapper<unknown, number>, tsql.IUsedRef<{
+    readonly myTable: {
+        readonly someColumnA: number;
+        readonly someColumnB: number;
+        readonly someColumnC: number;
+    };
+}>>;
+export declare const expr3: tsql.ExprImpl<tm.Mapper<unknown, number>, tsql.IUsedRef<{
+    readonly myTable: {
+        readonly someColumnA: number;
+        readonly someColumnB: number;
+        readonly someColumnC: number;
+    };
+}>>;
+export declare const expr4: tsql.ExprImpl<tm.Mapper<unknown, number>, tsql.IUsedRef<{
+    readonly myTable: {
+        readonly someColumnA: number;
+        readonly someColumnB: number;
+        readonly someColumnC: number;
+    };
+}>>;
+export declare const expr5: tsql.ExprImpl<tm.Mapper<unknown, number>, tsql.IUsedRef<{
+    readonly myTable: {
+        readonly someColumnA: number;
+        readonly someColumnB: number;
+        readonly someColumnC: number;
+    };
+}>>;

--- a/test/compile-time/expected-output/unified-query/as/can-be-used-as-expr-2.d.ts
+++ b/test/compile-time/expected-output/unified-query/as/can-be-used-as-expr-2.d.ts
@@ -1,7 +1,7 @@
 import * as tm from "type-mapping/fluent";
 import * as tsql from "../../../../../dist";
 export declare const aliased: tsql.ExprImpl<tm.Mapper<unknown, boolean>, tsql.IUsedRef<{
-    somethingElse: {
+    readonly somethingElse: {
         boop: bigint;
     };
 }>>;

--- a/test/compile-time/input/expr-library/double/power/long-chain.ts
+++ b/test/compile-time/input/expr-library/double/power/long-chain.ts
@@ -1,33 +1,33 @@
 import * as tm from "type-mapping/fluent";
-import * as tsql from "../../../../../../../dist";
+import * as tsql from "../../../../../../dist";
 
 const myTable = tsql.table("myTable")
     .addColumns({
-        someColumnA : tm.mysql.boolean(),
-        someColumnB : tm.mysql.boolean(),
-        someColumnC : tm.mysql.boolean(),
+        someColumnA : tm.mysql.double(),
+        someColumnB : tm.mysql.double(),
+        someColumnC : tm.mysql.double(),
     });
 
-export const expr = tsql.eq(
-    tsql.eq(
-        tsql.eq(
-            tsql.eq(
-                tsql.eq(
-                    tsql.eq(
-                        tsql.eq(
-                            tsql.eq(
-                                tsql.eq(
-                                    tsql.eq(
-                                        tsql.eq(
-                                            tsql.eq(
-                                                tsql.eq(
-                                                    tsql.eq(
-                                                        tsql.eq(
-                                                            tsql.eq(
-                                                                tsql.eq(
-                                                                    tsql.eq(
-                                                                        tsql.eq(
-                                                                            tsql.eq(
+export const expr = tsql.double.power(
+    tsql.double.power(
+        tsql.double.power(
+            tsql.double.power(
+                tsql.double.power(
+                    tsql.double.power(
+                        tsql.double.power(
+                            tsql.double.power(
+                                tsql.double.power(
+                                    tsql.double.power(
+                                        tsql.double.power(
+                                            tsql.double.power(
+                                                tsql.double.power(
+                                                    tsql.double.power(
+                                                        tsql.double.power(
+                                                            tsql.double.power(
+                                                                tsql.double.power(
+                                                                    tsql.double.power(
+                                                                        tsql.double.power(
+                                                                            tsql.double.power(
                                                                                 myTable.columns.someColumnA,
                                                                                 myTable.columns.someColumnB,
                                                                             ),
@@ -70,26 +70,26 @@ export const expr = tsql.eq(
     myTable.columns.someColumnC
 );
 
-export const expr2 = tsql.eq(
-    tsql.eq(
-        tsql.eq(
-            tsql.eq(
-                tsql.eq(
-                    tsql.eq(
-                        tsql.eq(
-                            tsql.eq(
-                                tsql.eq(
-                                    tsql.eq(
-                                        tsql.eq(
-                                            tsql.eq(
-                                                tsql.eq(
-                                                    tsql.eq(
-                                                        tsql.eq(
-                                                            tsql.eq(
-                                                                tsql.eq(
-                                                                    tsql.eq(
-                                                                        tsql.eq(
-                                                                            tsql.eq(
+export const expr2 = tsql.double.power(
+    tsql.double.power(
+        tsql.double.power(
+            tsql.double.power(
+                tsql.double.power(
+                    tsql.double.power(
+                        tsql.double.power(
+                            tsql.double.power(
+                                tsql.double.power(
+                                    tsql.double.power(
+                                        tsql.double.power(
+                                            tsql.double.power(
+                                                tsql.double.power(
+                                                    tsql.double.power(
+                                                        tsql.double.power(
+                                                            tsql.double.power(
+                                                                tsql.double.power(
+                                                                    tsql.double.power(
+                                                                        tsql.double.power(
+                                                                            tsql.double.power(
                                                                                 expr,
                                                                                 myTable.columns.someColumnA,
                                                                             ),
@@ -132,26 +132,26 @@ export const expr2 = tsql.eq(
     myTable.columns.someColumnB
 );
 
-export const expr3 = tsql.eq(
-    tsql.eq(
-        tsql.eq(
-            tsql.eq(
-                tsql.eq(
-                    tsql.eq(
-                        tsql.eq(
-                            tsql.eq(
-                                tsql.eq(
-                                    tsql.eq(
-                                        tsql.eq(
-                                            tsql.eq(
-                                                tsql.eq(
-                                                    tsql.eq(
-                                                        tsql.eq(
-                                                            tsql.eq(
-                                                                tsql.eq(
-                                                                    tsql.eq(
-                                                                        tsql.eq(
-                                                                            tsql.eq(
+export const expr3 = tsql.double.power(
+    tsql.double.power(
+        tsql.double.power(
+            tsql.double.power(
+                tsql.double.power(
+                    tsql.double.power(
+                        tsql.double.power(
+                            tsql.double.power(
+                                tsql.double.power(
+                                    tsql.double.power(
+                                        tsql.double.power(
+                                            tsql.double.power(
+                                                tsql.double.power(
+                                                    tsql.double.power(
+                                                        tsql.double.power(
+                                                            tsql.double.power(
+                                                                tsql.double.power(
+                                                                    tsql.double.power(
+                                                                        tsql.double.power(
+                                                                            tsql.double.power(
                                                                                 expr2,
                                                                                 myTable.columns.someColumnA,
                                                                             ),
@@ -194,26 +194,26 @@ export const expr3 = tsql.eq(
     myTable.columns.someColumnB
 );
 
-export const expr4 = tsql.eq(
-    tsql.eq(
-        tsql.eq(
-            tsql.eq(
-                tsql.eq(
-                    tsql.eq(
-                        tsql.eq(
-                            tsql.eq(
-                                tsql.eq(
-                                    tsql.eq(
-                                        tsql.eq(
-                                            tsql.eq(
-                                                tsql.eq(
-                                                    tsql.eq(
-                                                        tsql.eq(
-                                                            tsql.eq(
-                                                                tsql.eq(
-                                                                    tsql.eq(
-                                                                        tsql.eq(
-                                                                            tsql.eq(
+export const expr4 = tsql.double.power(
+    tsql.double.power(
+        tsql.double.power(
+            tsql.double.power(
+                tsql.double.power(
+                    tsql.double.power(
+                        tsql.double.power(
+                            tsql.double.power(
+                                tsql.double.power(
+                                    tsql.double.power(
+                                        tsql.double.power(
+                                            tsql.double.power(
+                                                tsql.double.power(
+                                                    tsql.double.power(
+                                                        tsql.double.power(
+                                                            tsql.double.power(
+                                                                tsql.double.power(
+                                                                    tsql.double.power(
+                                                                        tsql.double.power(
+                                                                            tsql.double.power(
                                                                                 expr3,
                                                                                 myTable.columns.someColumnA,
                                                                             ),
@@ -256,26 +256,26 @@ export const expr4 = tsql.eq(
     myTable.columns.someColumnB
 );
 
-export const expr5 = tsql.eq(
-    tsql.eq(
-        tsql.eq(
-            tsql.eq(
-                tsql.eq(
-                    tsql.eq(
-                        tsql.eq(
-                            tsql.eq(
-                                tsql.eq(
-                                    tsql.eq(
-                                        tsql.eq(
-                                            tsql.eq(
-                                                tsql.eq(
-                                                    tsql.eq(
-                                                        tsql.eq(
-                                                            tsql.eq(
-                                                                tsql.eq(
-                                                                    tsql.eq(
-                                                                        tsql.eq(
-                                                                            tsql.eq(
+export const expr5 = tsql.double.power(
+    tsql.double.power(
+        tsql.double.power(
+            tsql.double.power(
+                tsql.double.power(
+                    tsql.double.power(
+                        tsql.double.power(
+                            tsql.double.power(
+                                tsql.double.power(
+                                    tsql.double.power(
+                                        tsql.double.power(
+                                            tsql.double.power(
+                                                tsql.double.power(
+                                                    tsql.double.power(
+                                                        tsql.double.power(
+                                                            tsql.double.power(
+                                                                tsql.double.power(
+                                                                    tsql.double.power(
+                                                                        tsql.double.power(
+                                                                            tsql.double.power(
                                                                                 expr4,
                                                                                 myTable.columns.someColumnA,
                                                                             ),


### PR DESCRIPTION
https://github.com/AnyhowStep/tsql/pull/3/files#diff-685a95d488de4dc2af42c203b0d11765

Before adding `ExprUtil.Intersect<>`,
the test in the above file would give the following diagnostic error,
```js
{ file: undefined,
  start: undefined,
  length: undefined,
  messageText:
   'Type instantiation is excessively deep and possibly infinite.',
  category: 1,
  code: 2589,
  reportsUnnecessary: undefined }
```

It is **very** strange for an error to not be associated with a `file`.

-----

However, using `ExprUtil.Intersect<>` lets us nest calls to `tsql.double.power()` arbitrarily deep.

https://github.com/AnyhowStep/tsql/pull/3/files#diff-771034a2be293b77423fcebfae9a4a1eR19