### PR TITLE
Dogfood savepoint

### DIFF
--- a/src/column-map/util/constructor/from-mapper-map.ts
+++ b/src/column-map/util/constructor/from-mapper-map.ts
@@ -2,16 +2,18 @@ import * as tm from "type-mapping";
 import {WritableColumnMap} from "../../column-map";
 import {Column} from "../../../column";
 import {MapperMap} from "../../../mapper-map";
+import {Identity} from "../../../type-util";
 
-export type FromMapperMap<
+type FromMapperMapImpl<
     TableAliasT extends string,
-    MapperMapT extends MapperMap
-> = (
-    {
-        readonly [columnAlias in Extract<keyof MapperMapT, string>] : (
+    MapperMapT extends MapperMap,
+    ColumnAliasT extends keyof MapperMapT
+> =
+    Identity<{
+        readonly [columnAlias in ColumnAliasT] : (
             Column<{
                 tableAlias : TableAliasT,
-                columnAlias : columnAlias,
+                columnAlias : Extract<columnAlias, string>,
                 /**
                  * We erase the type of the `mapper` and
                  * replace it with `SafeMapper`.
@@ -21,7 +23,17 @@ export type FromMapperMap<
                 mapper : tm.SafeMapper<tm.OutputOf<MapperMapT[columnAlias]>>
             }>
         )
-    }
+    }>
+;
+export type FromMapperMap<
+    TableAliasT extends string,
+    MapperMapT extends MapperMap
+> = (
+    FromMapperMapImpl<
+        TableAliasT,
+        MapperMapT,
+        Extract<keyof MapperMapT, string>
+    >
 );
 export function fromMapperMap<
     TableAliasT extends string,

--- a/src/column-map/util/operation/intersect.ts
+++ b/src/column-map/util/operation/intersect.ts
@@ -1,20 +1,19 @@
 import {ColumnMap, WritableColumnMap} from "../../column-map";
 import {LeftIntersect, leftIntersect} from "./left-intersect";
-import {Merge} from "../../../type-util";
+import {Merge, ReadOnlyPick} from "../../../type-util";
 
 export type IntersectImpl<
     MapA extends ColumnMap,
     MapB extends ColumnMap,
 > = (
     & LeftIntersect<MapA, MapB>
-    & {
-        readonly [columnAlias in Exclude<
+    & ReadOnlyPick<
+        MapB,
+        Exclude<
             Extract<keyof MapB, string>,
             keyof MapA
-        >] : (
-            MapB[columnAlias]
-        )
-    }
+        >
+    >
 );
 export type Intersect<
     MapA extends ColumnMap,

--- a/src/column-map/util/operation/left-intersect.ts
+++ b/src/column-map/util/operation/left-intersect.ts
@@ -2,14 +2,15 @@ import * as tm from "type-mapping";
 import {ColumnMap, WritableColumnMap} from "../../column-map";
 import {Column, ColumnUtil} from "../../../column";
 import {DataTypeUtil} from "../../../data-type";
+import {Identity} from "../../../type-util";
 
-//Take the intersection and the "left" columnMap
-export type LeftIntersect<
+type LeftIntersectImpl<
     MapA extends ColumnMap,
     MapB extends ColumnMap,
-> = (
-    {
-        readonly [columnAlias in Extract<keyof MapA, string>] : (
+    ColumnAliasT extends keyof MapA
+> =
+    Identity<{
+        readonly [columnAlias in ColumnAliasT] : (
             columnAlias extends keyof MapB ?
             Column<{
                 tableAlias : MapA[columnAlias]["tableAlias"],
@@ -21,8 +22,15 @@ export type LeftIntersect<
             }> :
             MapA[columnAlias]
         )
-    }
-);
+    }>
+;
+//Take the intersection and the "left" columnMap
+export type LeftIntersect<
+    MapA extends ColumnMap,
+    MapB extends ColumnMap,
+> =
+    LeftIntersectImpl<MapA, MapB, Extract<keyof MapA, string>>
+;
 export function leftIntersect<
     MapA extends ColumnMap,
     MapB extends ColumnMap,

--- a/src/column-map/util/operation/with-table-alias.ts
+++ b/src/column-map/util/operation/with-table-alias.ts
@@ -1,19 +1,31 @@
 import {ColumnMap, WritableColumnMap} from "../../column-map";
 import {ColumnUtil} from "../../../column";
+import {Identity} from "../../../type-util";
 
-export type WithTableAlias<
+type WithTableAliasImpl<
     ColumnMapT extends ColumnMap,
-    NewTableAliasT extends string
-> = (
-    {
-        readonly [columnAlias in Extract<keyof ColumnMapT, string>] : (
+    NewTableAliasT extends string,
+    ColumnAliasT extends keyof ColumnMapT
+> =
+    Identity<{
+        readonly [columnAlias in ColumnAliasT] : (
             ColumnUtil.WithTableAlias<
                 ColumnMapT[columnAlias],
                 NewTableAliasT
             >
         )
-    }
-);
+    }>
+;
+export type WithTableAlias<
+    ColumnMapT extends ColumnMap,
+    NewTableAliasT extends string
+> =
+    WithTableAliasImpl<
+        ColumnMapT,
+        NewTableAliasT,
+        Extract<keyof ColumnMapT, string>
+    >
+;
 export function withTableAlias<
     ColumnMapT extends ColumnMap,
     NewTableAliasT extends string

--- a/src/design-pattern-table-per-type/util/execution-impl/update-and-fetch-one-impl.ts
+++ b/src/design-pattern-table-per-type/util/execution-impl/update-and-fetch-one-impl.ts
@@ -36,7 +36,10 @@ export interface UpdateAndFetchOneResult<RowT> {
 }
 
 /**
- * Not meant to be called externally
+ * Not meant to be called externally.
+ *
+ * **DOES NOT** use savepoints, internally.
+ * You **SHOULD** use savepoints before calling this function.
  */
 export async function updateAndFetchOneImpl<
     TptT extends ITablePerType

--- a/src/design-pattern-table-per-type/util/execution/insert-and-fetch.ts
+++ b/src/design-pattern-table-per-type/util/execution/insert-and-fetch.ts
@@ -54,75 +54,77 @@ export async function insertAndFetch<
      * @todo Add `assertInsertable()` or something
      */
     return connection.transactionIfNotInOne(IsolationLevel.REPEATABLE_READ, async (connection) : Promise<InsertedAndFetchedRow<TptT, RowT>> => {
-        const generated = generatedColumnAliases(tpt);
+        return connection.savepoint(async (connection) : Promise<InsertedAndFetchedRow<TptT, RowT>> => {
+            const generated = generatedColumnAliases(tpt);
 
-        const result : any = omitOwnEnumerable(
-            insertRow,
-            [
-                /**
-                 * We omit implicit auto-increment values because we do not
-                 * want them to be set by users of the library.
-                 */
-                ...implicitAutoIncrement(tpt),
-                /**
-                 * We omit generated values because users can't set them, anyway.
-                 */
-                ...generated,
-            ] as any
-        );
-
-        for(const columnAlias of generated) {
-            const table = findTableWithGeneratedColumnAlias(
-                tpt,
-                columnAlias
+            const result : any = omitOwnEnumerable(
+                insertRow,
+                [
+                    /**
+                     * We omit implicit auto-increment values because we do not
+                     * want them to be set by users of the library.
+                     */
+                    ...implicitAutoIncrement(tpt),
+                    /**
+                     * We omit generated values because users can't set them, anyway.
+                     */
+                    ...generated,
+                ] as any
             );
 
-            const sqlString = await connection.tryFetchGeneratedColumnExpression(
-                TableUtil.tryGetSchemaName(table),
-                table.alias,
-                columnAlias
-            );
+            for(const columnAlias of generated) {
+                const table = findTableWithGeneratedColumnAlias(
+                    tpt,
+                    columnAlias
+                );
 
-            if (sqlString == undefined) {
-                throw new Error(`Generated column ${table.alias}.${columnAlias} should have generation expression`);
+                const sqlString = await connection.tryFetchGeneratedColumnExpression(
+                    TableUtil.tryGetSchemaName(table),
+                    table.alias,
+                    columnAlias
+                );
+
+                if (sqlString == undefined) {
+                    throw new Error(`Generated column ${table.alias}.${columnAlias} should have generation expression`);
+                }
+
+                result[columnAlias] = expr(
+                    {
+                        mapper : table.columns[columnAlias].mapper,
+                        usedRef : UsedRefUtil.fromColumnRef({}),
+                    },
+                    /**
+                     * This `sqlString` is not allowed to reference any columns.
+                     * If it does, there is a very high chance that it will cause an error.
+                     *
+                     * @todo Find use case where we need to allow this to reference columns.
+                     */
+                    sqlString
+                );
             }
 
-            result[columnAlias] = expr(
-                {
-                    mapper : table.columns[columnAlias].mapper,
-                    usedRef : UsedRefUtil.fromColumnRef({}),
-                },
-                /**
-                 * This `sqlString` is not allowed to reference any columns.
-                 * If it does, there is a very high chance that it will cause an error.
-                 *
-                 * @todo Find use case where we need to allow this to reference columns.
-                 */
-                sqlString
-            );
-        }
+            for(const table of [...tpt.parentTables, tpt.childTable]) {
+                const fetchedRow = await ExecutionUtil.insertAndFetch(
+                    (
+                        /**
+                         * We want to allow explicit auto-increment values internally,
+                         * so that the same value is used for all tables of the same
+                         * inheritance hierarchy.
+                         */
+                        table.autoIncrement != undefined && !table.explicitAutoIncrementValueEnabled ?
+                        {
+                            ...table,
+                            explicitAutoIncrementValueEnabled : true,
+                        } :
+                        table
+                    ),
+                    connection,
+                    result as never
+                );
+                absorbRow(result, table, fetchedRow);
+            }
 
-        for(const table of [...tpt.parentTables, tpt.childTable]) {
-            const fetchedRow = await ExecutionUtil.insertAndFetch(
-                (
-                    /**
-                     * We want to allow explicit auto-increment values internally,
-                     * so that the same value is used for all tables of the same
-                     * inheritance hierarchy.
-                     */
-                    table.autoIncrement != undefined && !table.explicitAutoIncrementValueEnabled ?
-                    {
-                        ...table,
-                        explicitAutoIncrementValueEnabled : true,
-                    } :
-                    table
-                ),
-                connection,
-                result as never
-            );
-            absorbRow(result, table, fetchedRow);
-        }
-
-        return result;
+            return result;
+        });
     });
 }

--- a/src/design-pattern-table-per-type/util/execution/insert-and-fetch.ts
+++ b/src/design-pattern-table-per-type/util/execution/insert-and-fetch.ts
@@ -105,21 +105,24 @@ export async function insertAndFetch<
 
             for(const table of [...tpt.parentTables, tpt.childTable]) {
                 const fetchedRow = await ExecutionUtil.insertAndFetch(
-                    (
+                    /**
+                     * We use `InsertAndFetchOptions`, instead of creating
+                     * a new table instance because we want events to use the
+                     * original `table` instance.
+                     *
+                     * `event.isFor()` methods use `===` internally
+                     */
+                    table,
+                    connection,
+                    result as never,
+                    {
                         /**
                          * We want to allow explicit auto-increment values internally,
                          * so that the same value is used for all tables of the same
                          * inheritance hierarchy.
                          */
-                        table.autoIncrement != undefined && !table.explicitAutoIncrementValueEnabled ?
-                        {
-                            ...table,
-                            explicitAutoIncrementValueEnabled : true,
-                        } :
-                        table
-                    ),
-                    connection,
-                    result as never
+                        explicitAutoIncrementValueEnabled : true,
+                    }
                 );
                 absorbRow(result, table, fetchedRow);
             }

--- a/src/design-pattern-table-per-type/util/execution/update-and-fetch-one-by-super-key.ts
+++ b/src/design-pattern-table-per-type/util/execution/update-and-fetch-one-by-super-key.ts
@@ -18,49 +18,51 @@ export async function updateAndFetchOneBySuperKey<
     assignmentMapDelegate : AssignmentMapDelegate<TptT, AssignmentMapT>
 ) : Promise<UpdateAndFetchOneReturnType<TptT, AssignmentMapT>> {
     return connection.transactionIfNotInOne(IsolationLevel.REPEATABLE_READ, async (connection) : Promise<UpdateAndFetchOneReturnType<TptT, AssignmentMapT>> => {
-        const cleanedAssignmentMap = await invokeAssignmentDelegate(
-            tpt,
-            connection,
-            () => eqSuperKey(
+        return connection.savepoint(async (connection) : Promise<UpdateAndFetchOneReturnType<TptT, AssignmentMapT>> => {
+            const cleanedAssignmentMap = await invokeAssignmentDelegate(
                 tpt,
-                superKey
-            ) as any,
-            assignmentMapDelegate
-        );
-        /**
-         * @todo If `result` contains any primaryKey values,
-         * then we will need to fetch the **current** primaryKey values,
-         * before any `UPDATE` statements are executed.
-         *
-         * This function breaks if we try to update values
-         * of columns that are foreign keys.
-         *
-         * I do not want to disable foreign key checks.
-         */
-        const updateAndFetchChildResult = await ExecutionUtil.updateAndFetchOneByCandidateKey(
-            tpt.childTable,
-            connection,
+                connection,
+                () => eqSuperKey(
+                    tpt,
+                    superKey
+                ) as any,
+                assignmentMapDelegate
+            );
             /**
-             * We have already used the `superKey` to "clean" our assignment map.
-             * So, we can be reasonably sure that the `superKey` itself
-             * refers to exactly one row that exists.
+             * @todo If `result` contains any primaryKey values,
+             * then we will need to fetch the **current** primaryKey values,
+             * before any `UPDATE` statements are executed.
              *
-             * Now, we can pretend this `superKey` is a `candidateKey`,
-             * discarding all non-key columns.
+             * This function breaks if we try to update values
+             * of columns that are foreign keys.
              *
-             * This should not introduce any bugs.
+             * I do not want to disable foreign key checks.
              */
-            superKey,
-            () => pickOwnEnumerable(
+            const updateAndFetchChildResult = await ExecutionUtil.updateAndFetchOneByCandidateKey(
+                tpt.childTable,
+                connection,
+                /**
+                 * We have already used the `superKey` to "clean" our assignment map.
+                 * So, we can be reasonably sure that the `superKey` itself
+                 * refers to exactly one row that exists.
+                 *
+                 * Now, we can pretend this `superKey` is a `candidateKey`,
+                 * discarding all non-key columns.
+                 *
+                 * This should not introduce any bugs.
+                 */
+                superKey,
+                () => pickOwnEnumerable(
+                    cleanedAssignmentMap,
+                    tpt.childTable.mutableColumns
+                ) as any
+            );
+            return updateAndFetchOneImpl(
+                tpt,
+                connection,
                 cleanedAssignmentMap,
-                tpt.childTable.mutableColumns
-            ) as any
-        );
-        return updateAndFetchOneImpl(
-            tpt,
-            connection,
-            cleanedAssignmentMap,
-            updateAndFetchChildResult
-        ) as Promise<UpdateAndFetchOneReturnType<TptT, AssignmentMapT>>;
+                updateAndFetchChildResult
+            ) as Promise<UpdateAndFetchOneReturnType<TptT, AssignmentMapT>>;
+        });
     });
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -56,14 +56,6 @@ export class TooManyColumnsSelectedError extends Error {
 }
 TooManyColumnsSelectedError.prototype.name = "TooManyColumnsSelectedError";
 
-export class TooManyRowsUpdatedError extends Error {
-    constructor (message : string) {
-        super(message);
-        Object.setPrototypeOf(this, TooManyRowsUpdatedError.prototype);
-    }
-}
-TooManyRowsUpdatedError.prototype.name = "TooManyRowsUpdatedError";
-
 export class CannotCountError extends Error {
     constructor (message : string) {
         super(message);

--- a/src/execution/util/operation-update/update-and-fetch-one-impl.ts
+++ b/src/execution/util/operation-update/update-and-fetch-one-impl.ts
@@ -89,34 +89,40 @@ export async function updateAndFetchOneImpl<
             updateResult : UpdateAndFetchOneResult<TableT, AssignmentMapT>,
             assignmentMap : AssignmentMapT,
         }> => {
-            const {
-                updateWhereDelegate,
-                fetchWhereDelegate,
-                assignmentMap,
-            } = await initCallback(connection);
-            const {
-                whereClause : updateWhereClause,
-                updateResult : updateOneResult,
-            } = await updateOneImplNoEvent(
-                table,
-                connection,
-                updateWhereDelegate,
-                () => assignmentMap
-            );
-            const row = await TableUtil.__fetchOneHelper(
-                table,
-                connection,
-                fetchWhereDelegate
-            );
+            return connection.savepoint(async (connection) : Promise<{
+                updateWhereClause : WhereClause,
+                updateResult : UpdateAndFetchOneResult<TableT, AssignmentMapT>,
+                assignmentMap : AssignmentMapT,
+            }> => {
+                const {
+                    updateWhereDelegate,
+                    fetchWhereDelegate,
+                    assignmentMap,
+                } = await initCallback(connection);
+                const {
+                    whereClause : updateWhereClause,
+                    updateResult : updateOneResult,
+                } = await updateOneImplNoEvent(
+                    table,
+                    connection,
+                    updateWhereDelegate,
+                    () => assignmentMap
+                );
+                const row = await TableUtil.__fetchOneHelper(
+                    table,
+                    connection,
+                    fetchWhereDelegate
+                );
 
-            return {
-                updateWhereClause,
-                updateResult : {
-                    ...updateOneResult,
-                    row,
-                },
-                assignmentMap,
-            };
+                return {
+                    updateWhereClause,
+                    updateResult : {
+                        ...updateOneResult,
+                        row,
+                    },
+                    assignmentMap,
+                };
+            });
         });
 
         const fullConnection = connection.tryGetFullConnection();

--- a/src/execution/util/operation-update/update-zero-or-one.ts
+++ b/src/execution/util/operation-update/update-zero-or-one.ts
@@ -60,47 +60,53 @@ export async function updateZeroOrOneImplNoEvent<
         assignmentMap : BuiltInAssignmentMap<TableT>,
         updateResult : UpdateZeroOrOneResult,
     }> => {
-        const {
-            whereClause,
-            assignmentMap,
-            updateResult,
-        } = await impl.updateImplNoEvent(
-            table,
-            connection,
-            whereDelegate,
-            assignmentMapDelegate
-        );
-        if (tm.BigIntUtil.equal(updateResult.foundRowCount, tm.BigInt(0))) {
-            if (tm.BigIntUtil.equal(updateResult.updatedRowCount, tm.BigInt(0))) {
-                return {
-                    whereClause,
-                    assignmentMap,
-                    updateResult : updateResult as NotFoundUpdateResult,
-                };
-            } else {
-                //Should never happen...
-                throw new Error(`Expected to update zero rows of ${table.alias}; updated ${updateResult.updatedRowCount}`);
+        return connection.savepoint(async (connection) : Promise<{
+            whereClause : WhereClause,
+            assignmentMap : BuiltInAssignmentMap<TableT>,
+            updateResult : UpdateZeroOrOneResult,
+        }> => {
+            const {
+                whereClause,
+                assignmentMap,
+                updateResult,
+            } = await impl.updateImplNoEvent(
+                table,
+                connection,
+                whereDelegate,
+                assignmentMapDelegate
+            );
+            if (tm.BigIntUtil.equal(updateResult.foundRowCount, tm.BigInt(0))) {
+                if (tm.BigIntUtil.equal(updateResult.updatedRowCount, tm.BigInt(0))) {
+                    return {
+                        whereClause,
+                        assignmentMap,
+                        updateResult : updateResult as NotFoundUpdateResult,
+                    };
+                } else {
+                    //Should never happen...
+                    throw new Error(`Expected to update zero rows of ${table.alias}; updated ${updateResult.updatedRowCount}`);
+                }
             }
-        }
-        if (tm.BigIntUtil.equal(updateResult.foundRowCount, tm.BigInt(1))) {
-            if (
-                tm.BigIntUtil.equal(updateResult.updatedRowCount, tm.BigInt(0)) ||
-                tm.BigIntUtil.equal(updateResult.updatedRowCount, tm.BigInt(1))
-            ) {
-                return {
-                    whereClause,
-                    assignmentMap,
-                    updateResult : updateResult as UpdateOneResult,
-                };
-            } else {
-                //Should never happen...
-                throw new Error(`Expected to update zero or one row of ${table.alias}; updated ${updateResult.updatedRowCount}`);
+            if (tm.BigIntUtil.equal(updateResult.foundRowCount, tm.BigInt(1))) {
+                if (
+                    tm.BigIntUtil.equal(updateResult.updatedRowCount, tm.BigInt(0)) ||
+                    tm.BigIntUtil.equal(updateResult.updatedRowCount, tm.BigInt(1))
+                ) {
+                    return {
+                        whereClause,
+                        assignmentMap,
+                        updateResult : updateResult as UpdateOneResult,
+                    };
+                } else {
+                    //Should never happen...
+                    throw new Error(`Expected to update zero or one row of ${table.alias}; updated ${updateResult.updatedRowCount}`);
+                }
             }
-        }
-        throw new TooManyRowsFoundError(
-            `Expected to find one row of ${table.alias}; found ${updateResult.foundRowCount} rows`,
-            updateResult.query.sql
-        );
+            throw new TooManyRowsFoundError(
+                `Expected to find one row of ${table.alias}; found ${updateResult.foundRowCount} rows`,
+                updateResult.query.sql
+            );
+        });
     });
 }
 

--- a/src/table/util/operation/set-primary-key.ts
+++ b/src/table/util/operation/set-primary-key.ts
@@ -4,7 +4,7 @@ import {Table} from "../../table-impl";
 import {ColumnUtil, IColumn, ColumnArrayUtil} from "../../../column";
 import {AssertValidCandidateKey, assertValidCandidateKey} from "./add-candidate-key";
 import {KeyArrayUtil, KeyUtil} from "../../../key";
-import {pickOwnEnumerable} from "../../../type-util";
+import {pickOwnEnumerable, ReadOnlyPick} from "../../../type-util";
 
 /**
  * @todo Allow custom data types for primary key.
@@ -23,13 +23,9 @@ export type SetPrimaryKeyColumnAlias<TableT extends Pick<ITable, "columns">> = (
     }[Extract<keyof TableT["columns"], string>]
 );
 
-export type SetPrimaryKeyColumnMap<TableT extends Pick<ITable, "columns">> = (
-    {
-        readonly [columnName in SetPrimaryKeyColumnAlias<TableT>] : (
-            TableT["columns"][columnName]
-        )
-    }
-);
+export type SetPrimaryKeyColumnMap<TableT extends Pick<ITable, "columns">> =
+    ReadOnlyPick<TableT["columns"], SetPrimaryKeyColumnAlias<TableT>>
+;
 export function setPrimaryKeyColumnMap<
     TableT extends Pick<ITable, "columns">
 > (

--- a/src/type-util/pick-multi.ts
+++ b/src/type-util/pick-multi.ts
@@ -1,3 +1,5 @@
+import {Identity} from "./identity";
+
 /**
  * + Assumes `T` is not a union
  * + Lets `KeyT` be a union
@@ -22,4 +24,10 @@ export type DistributePick<
     T extends any ?
     Pick<T, Extract<KeyT, keyof T>> :
     never
+;
+
+export type ReadOnlyPick<T, K extends keyof T> =
+    Identity<{
+        readonly [k in K] : T[k]
+    }>
 ;

--- a/test/compile-time/expected-output/select-clause/select/widened-column-type-allowed.d.ts
+++ b/test/compile-time/expected-output/select-clause/select/widened-column-type-allowed.d.ts
@@ -2,6 +2,10 @@ import * as tm from "type-mapping/fluent";
 import * as tsql from "../../../../../dist";
 export declare const selectClause: [tsql.Column<{
     tableAlias: "otherTable";
-    columnAlias: "otherTableId";
+    columnAlias: "otherTableId"; /**
+     * No idea why you would want to do this...
+     * But it's technically sound,
+     * assuming the original table is not lying about the column type.
+     */
     mapper: tm.Mapper<unknown, bigint | boolean | null>;
 }>];

--- a/test/compile-time/expected-output/table/as/long-chain.d.ts
+++ b/test/compile-time/expected-output/table/as/long-chain.d.ts
@@ -2,60 +2,60 @@ import * as tm from "type-mapping";
 import * as tsql from "../../../../../dist";
 export declare const aliasedTable: tsql.Table<{
     isLateral: false;
-    alias: "21";
+    alias: "19";
     columns: {
         readonly myTableId: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "myTableId";
             mapper: tm.Mapper<unknown, bigint>;
         }>;
         readonly column0: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column0";
             mapper: tm.Mapper<unknown, string>;
         }>;
         readonly column1: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column1";
             mapper: tm.Mapper<unknown, Buffer>;
         }>;
         readonly column2: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column2";
             mapper: tm.Mapper<unknown, Date>;
         }>;
         readonly column3: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column3";
             mapper: tm.Mapper<unknown, bigint>;
         }>;
         readonly column4: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column4";
             mapper: tm.Mapper<unknown, bigint>;
         }>;
         readonly column5: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column5";
             mapper: tm.Mapper<unknown, boolean>;
         }>;
         readonly column6: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column6";
             mapper: tm.Mapper<unknown, string>;
         }>;
         readonly column7: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column7";
             mapper: tm.Mapper<unknown, string>;
         }>;
         readonly column8: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column8";
             mapper: tm.Mapper<unknown, string>;
         }>;
         readonly column9: tsql.Column<{
-            tableAlias: "21";
+            tableAlias: "19";
             columnAlias: "column9";
             mapper: tm.Mapper<unknown, string>;
         }>;

--- a/test/compile-time/expected-output/unified-query/where-is-not-null/long-chain.d.ts
+++ b/test/compile-time/expected-output/unified-query/where-is-not-null/long-chain.d.ts
@@ -190,7 +190,7 @@ export declare const query: tsql.Query<{
                 readonly column36: tsql.Column<{
                     tableAlias: "myTable";
                     columnAlias: "column36";
-                    mapper: tm.Mapper<unknown, bigint>;
+                    mapper: tm.Mapper<unknown, bigint | null>;
                 }>;
                 readonly column37: tsql.Column<{
                     tableAlias: "myTable";

--- a/test/compile-time/expected-output/unified-query/where-is-not-null/long-chain.ts.errors
+++ b/test/compile-time/expected-output/unified-query/where-is-not-null/long-chain.ts.errors
@@ -4,11 +4,11 @@
     "code": 2589,
     "category": 1,
     "length": 55,
-    "start": 4689
+    "start": 4737
   },
   {
     "messageText": {
-      "messageText": "Argument of type '(columns: { readonly column37: Column<{ tableAlias: \"myTable\"; columnAlias: \"column37\"; mapper: Mapper<unknown, bigint | null>; }>; }) => Column<{ tableAlias: \"myTable\"; columnAlias: \"column37\"; mapper: Mapper<...>; }>' is not assignable to parameter of type '(columns: { readonly [x: string]: { readonly [x: string]: any; }; }) => Column<{ tableAlias: \"myTable\"; columnAlias: \"column37\"; mapper: Mapper<unknown, bigint | null>; }>'.",
+      "messageText": "Argument of type '(columns: { readonly column36: Column<{ tableAlias: \"myTable\"; columnAlias: \"column36\"; mapper: Mapper<unknown, bigint | null>; }>; readonly column37: Column<{ tableAlias: \"myTable\"; columnAlias: \"column37\"; mapper: Mapper<...>; }>; }) => Column<...>' is not assignable to parameter of type '(columns: { readonly [x: string]: { readonly [x: string]: any; }; }) => Column<{ tableAlias: \"myTable\"; columnAlias: \"column37\"; mapper: Mapper<unknown, bigint | null>; }>'.",
       "category": 1,
       "code": 2345,
       "next": {
@@ -16,15 +16,15 @@
         "category": 1,
         "code": 2328,
         "next": {
-          "messageText": "Property 'column37' is missing in type '{ readonly [x: string]: { readonly [x: string]: any; }; }' but required in type '{ readonly column37: Column<{ tableAlias: \"myTable\"; columnAlias: \"column37\"; mapper: Mapper<unknown, bigint | null>; }>; }'.",
+          "messageText": "Type '{ readonly [x: string]: { readonly [x: string]: any; }; }' is missing the following properties from type '{ readonly column36: Column<{ tableAlias: \"myTable\"; columnAlias: \"column36\"; mapper: Mapper<unknown, bigint | null>; }>; readonly column37: Column<{ tableAlias: \"myTable\"; columnAlias: \"column37\"; mapper: Mapper<...>; }>; }': column36, column37",
           "category": 1,
-          "code": 2741
+          "code": 2739
         }
       }
     },
     "code": 2345,
     "category": 1,
     "length": 27,
-    "start": 4715
+    "start": 4763
   }
 ]

--- a/test/compile-time/input/table/as/long-chain.ts
+++ b/test/compile-time/input/table/as/long-chain.ts
@@ -13,6 +13,9 @@ const myTable = tsql.table("myTable")
         column6 : tm.mysql.json(),
         column7 : tm.mysql.varChar(255),
         column8 : tm.mysql.varChar(255),
+        /**
+         * Comment
+         */
         column9 : tm.mysql.varChar(255),
     });
 
@@ -36,9 +39,9 @@ export const aliasedTable = myTable
     .as("16")
     .as("17")
     .as("18")
-    .as("19")
-    .as("20")
-    .as("21");
+    .as("19");
+    //.as("20");
+    //.as("21");
 /**
  * The type of `columns.column0.columnAlias` is all messed up.
  * No max-depth error, though.

--- a/test/compile-time/input/unified-query/where-is-not-null/long-chain.ts
+++ b/test/compile-time/input/unified-query/where-is-not-null/long-chain.ts
@@ -40,6 +40,9 @@ const myTable = tsql.table("myTable")
         column34 : tm.mysql.bigIntUnsigned().orNull(),
         column35 : tm.mysql.bigIntUnsigned().orNull(),
         column36 : tm.mysql.bigIntUnsigned().orNull(),
+        /**
+         * Comment
+         */
         column37 : tm.mysql.bigIntUnsigned().orNull(),
     });
 
@@ -152,10 +155,10 @@ export const query = tsql.QueryUtil.newInstance()
     )
     .whereIsNotNull(
         columns => columns.column35
-    )
-    .whereIsNotNull(
-        columns => columns.column36
     );
+    /*.whereIsNotNull(
+        columns => columns.column36
+    );*/
 /**
  * @todo Find a way to increase the limit to 60 or more
  */

--- a/test/run-time/input/connection/savepoint/delete-one/delete-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-more-than-one-in-savepoint.ts
@@ -1,0 +1,79 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        return connection.transaction(async (connection) => {
+            return connection.savepoint(async (connection) => {
+                /**
+                 * This should end up deleting two rows,
+                 * which should throw an error,
+                 * which should rollback to savepoint,
+                 * causing no rows to be deleted
+                 */
+                await dst.deleteOne(
+                    connection,
+                    columns => tsql.gt(
+                        columns.testVal,
+                        BigInt(100)
+                    )
+                ).then(() => {
+                    t.fail("Should not be able to delete two rows");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/delete-one/delete-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-more-than-one-in-transaction.ts
@@ -26,41 +26,24 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
-
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
+        return connection.transaction(async (connection) => {
+            /**
+             * This should end up deleting two rows,
+             * which should throw an error,
+             * which should rollback to savepoint,
+             * causing no rows to be deleted
+             */
+            await dst.deleteOne(
+                connection,
+                columns => tsql.gt(
+                    columns.testVal,
+                    BigInt(100)
+                )
+            ).then(() => {
+                t.fail("Should not be able to delete two rows");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
             });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
-        await connection.transaction(async (connection) => {
-            await connection.savepoint(async (connection) => {
-                await dst.deleteOne(
-                    connection,
-                    columns => tsql.eq(
-                        columns.testVal,
-                        BigInt(200)
-                    )
-                );
-                t.deepEqual(handlerInvoked, true);
-                t.deepEqual(commitInvoked, false);
-                t.deepEqual(rollbackInvoked, false);
-            });
-            t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, false);
-            t.deepEqual(rollbackInvoked, false);
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -77,6 +60,10 @@ tape(__filename, async (t) => {
                                 testVal : BigInt(100),
                             },
                             {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
                                 testId : BigInt(3),
                                 testVal : BigInt(300),
                             },
@@ -84,9 +71,6 @@ tape(__filename, async (t) => {
                     );
                 });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-one/delete-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-more-than-one.ts
@@ -26,52 +26,49 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        return connection.transaction(async (connection) => {
-            /**
-             * This should end up deleting two rows,
-             * which should throw an error,
-             * which should rollback to savepoint,
-             * causing no rows to be deleted
-             */
-            await tsql.ExecutionUtil.deleteOne(
-                dst,
-                connection,
-                columns => tsql.gt(
-                    columns.testVal,
-                    BigInt(100)
-                )
-            ).then(() => {
-                t.fail("Should not be able to delete two rows");
-            }).catch((err) => {
-                t.true(err instanceof tsql.TooManyRowsFoundError);
-            });
-
-            await tsql.from(dst)
-                .select(columns => [columns])
-                .orderBy(columns => [
-                    columns.testId.asc(),
-                ])
-                .fetchAll(connection)
-                .then((rows) => {
-                    t.deepEqual(
-                        rows,
-                        [
-                            {
-                                testId : BigInt(1),
-                                testVal : BigInt(100),
-                            },
-                            {
-                                testId : BigInt(2),
-                                testVal : BigInt(200),
-                            },
-                            {
-                                testId : BigInt(3),
-                                testVal : BigInt(300),
-                            },
-                        ]
-                    );
-                });
+        /**
+         * This should end up deleting two rows,
+         * which should throw an error,
+         * which should rollback to savepoint,
+         * causing no rows to be deleted
+         */
+        await dst.deleteOne(
+            connection,
+            columns => tsql.gt(
+                columns.testVal,
+                BigInt(100)
+            )
+        ).then(() => {
+            t.fail("Should not be able to delete two rows");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
         });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-one/delete-one-commit-2.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-one-commit-2.ts
@@ -47,8 +47,7 @@ tape(__filename, async (t) => {
 
         await connection.transaction(async (connection) => {
             await connection.savepoint(async (connection) => {
-                await tsql.ExecutionUtil.deleteOne(
-                    dst,
+                await dst.deleteOne(
                     connection,
                     columns => tsql.eq(
                         columns.testVal,

--- a/test/run-time/input/connection/savepoint/delete-one/delete-one-commit-3.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-one-commit-3.ts
@@ -48,8 +48,7 @@ tape(__filename, async (t) => {
         await connection.transaction(async (connection) => {
             await connection.savepoint(async (connection) => {
                 await connection.savepoint(async (connection) => {
-                    await tsql.ExecutionUtil.deleteOne(
-                        dst,
+                    await dst.deleteOne(
                         connection,
                         columns => tsql.eq(
                             columns.testVal,

--- a/test/run-time/input/connection/savepoint/delete-one/delete-one-commit-5.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-one-commit-5.ts
@@ -48,8 +48,7 @@ tape(__filename, async (t) => {
         await connection.transaction(async (connection) => {
             await connection.savepoint(async (connection) => {
                 await connection.savepoint(async (connection) => {
-                    await tsql.ExecutionUtil.deleteOne(
-                        dst,
+                    await dst.deleteOne(
                         connection,
                         columns => tsql.eq(
                             columns.testVal,

--- a/test/run-time/input/connection/savepoint/delete-one/delete-one-in-nested-savepoint-rollback-to-savepoint-in-parent-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-one-in-nested-savepoint-rollback-to-savepoint-in-parent-savepoint.ts
@@ -57,8 +57,7 @@ tape(__filename, async (t) => {
                     /**
                      * This should delete exactly one row.
                      */
-                    await tsql.ExecutionUtil.deleteOne(
-                        dst,
+                    await dst.deleteOne(
                         connection,
                         columns => tsql.eq(
                             columns.testVal,
@@ -74,35 +73,13 @@ tape(__filename, async (t) => {
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, false);
 
+                await connection.rollbackToSavepoint();
+
+                t.deepEqual(handlerInvoked, true);
+                t.deepEqual(commitInvoked, false);
+                t.deepEqual(rollbackInvoked, true);
+
             });
-
-            await tsql.from(dst)
-                .select(columns => [columns])
-                .orderBy(columns => [
-                    columns.testId.asc(),
-                ])
-                .fetchAll(connection)
-                .then((rows) => {
-                    t.deepEqual(
-                        rows,
-                        [
-                            {
-                                testId : BigInt(1),
-                                testVal : BigInt(100),
-                            },
-                            {
-                                testId : BigInt(3),
-                                testVal : BigInt(300),
-                            },
-                        ]
-                    );
-                });
-
-            t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, false);
-            t.deepEqual(rollbackInvoked, false);
-
-            await connection.rollback();
 
             t.deepEqual(handlerInvoked, true);
             t.deepEqual(commitInvoked, false);

--- a/test/run-time/input/connection/savepoint/delete-one/delete-one-in-nested-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-one-in-nested-savepoint-rollback.ts
@@ -57,8 +57,7 @@ tape(__filename, async (t) => {
                     /**
                      * This should delete exactly one row.
                      */
-                    await tsql.ExecutionUtil.deleteOne(
-                        dst,
+                    await dst.deleteOne(
                         connection,
                         columns => tsql.eq(
                             columns.testVal,
@@ -68,20 +67,19 @@ tape(__filename, async (t) => {
                     t.deepEqual(handlerInvoked, true);
                     t.deepEqual(commitInvoked, false);
                     t.deepEqual(rollbackInvoked, false);
+
+                    await connection.rollback();
+
+                    t.deepEqual(handlerInvoked, true);
+                    t.deepEqual(commitInvoked, false);
+                    t.deepEqual(rollbackInvoked, true);
+
                 });
-
-                t.deepEqual(handlerInvoked, true);
-                t.deepEqual(commitInvoked, false);
-                t.deepEqual(rollbackInvoked, false);
-
-                throw new Error(`Blah`);
-            }).catch((err) => {
 
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, true);
 
-                t.deepEqual(err.message, `Blah`);
             });
 
             t.deepEqual(handlerInvoked, true);

--- a/test/run-time/input/connection/savepoint/delete-one/delete-one-in-nested-savepoint-throw-error-in-parent-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-one-in-nested-savepoint-throw-error-in-parent-savepoint.ts
@@ -26,28 +26,37 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
+        return connection.transaction(async (connection) => {
+            let handlerInvoked = false;
+            let commitInvoked = false;
+            let rollbackInvoked = false;
 
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
-            });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
-        await connection.transaction(async (connection) => {
+            /**
+             * This savepoint will be rolled back.
+             */
             await connection.savepoint(async (connection) => {
+                /**
+                 * This savepoint will be released.
+                 */
                 await connection.savepoint(async (connection) => {
+                    const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
+                        t.deepEqual(handlerInvoked, false);
+                        handlerInvoked = true;
+
+                        evt.addOnCommitListener(() => {
+                            t.fail("Should not invoke commit listener");
+                            commitInvoked = true;
+                        });
+
+                        evt.addOnRollbackListener(() => {
+                            t.deepEqual(rollbackInvoked, false);
+                            rollbackInvoked = true;
+                        });
+                    };
+                    pool.onDelete.addHandler(myDeleteHandler);
+                    /**
+                     * This should delete exactly one row.
+                     */
                     await dst.deleteOne(
                         connection,
                         columns => tsql.eq(
@@ -58,27 +67,25 @@ tape(__filename, async (t) => {
                     t.deepEqual(handlerInvoked, true);
                     t.deepEqual(commitInvoked, false);
                     t.deepEqual(rollbackInvoked, false);
-
-                    await connection.releaseSavepoint();
-
-                    t.deepEqual(handlerInvoked, true);
-                    t.deepEqual(commitInvoked, false);
-                    t.deepEqual(rollbackInvoked, false);
                 });
 
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, false);
 
-                await connection.commit();
+                throw new Error(`Blah`);
+            }).catch((err) => {
 
                 t.deepEqual(handlerInvoked, true);
-                t.deepEqual(commitInvoked, true);
-                t.deepEqual(rollbackInvoked, false);
+                t.deepEqual(commitInvoked, false);
+                t.deepEqual(rollbackInvoked, true);
+
+                t.deepEqual(err.message, `Blah`);
             });
+
             t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, true);
-            t.deepEqual(rollbackInvoked, false);
+            t.deepEqual(commitInvoked, false);
+            t.deepEqual(rollbackInvoked, true);
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -95,6 +102,10 @@ tape(__filename, async (t) => {
                                 testVal : BigInt(100),
                             },
                             {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
                                 testId : BigInt(3),
                                 testVal : BigInt(300),
                             },
@@ -102,9 +113,6 @@ tape(__filename, async (t) => {
                     );
                 });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-one/delete-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-one-in-savepoint-rollback-to-savepoint.ts
@@ -26,27 +26,29 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
-
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
-            });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
-        await connection.transaction(async (connection) => {
+        return connection.transaction(async (connection) => {
             await connection.savepoint(async (connection) => {
+                let handlerInvoked = false;
+                let commitInvoked = false;
+                let rollbackInvoked = false;
+                const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
+                    t.deepEqual(handlerInvoked, false);
+                    handlerInvoked = true;
+
+                    evt.addOnCommitListener(() => {
+                        t.fail("Should not invoke commit listener");
+                        commitInvoked = true;
+                    });
+
+                    evt.addOnRollbackListener(() => {
+                        t.deepEqual(rollbackInvoked, false);
+                        rollbackInvoked = true;
+                    });
+                };
+                pool.onDelete.addHandler(myDeleteHandler);
+                /**
+                 * This should delete exactly one row.
+                 */
                 await dst.deleteOne(
                     connection,
                     columns => tsql.eq(
@@ -57,10 +59,13 @@ tape(__filename, async (t) => {
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, false);
+
+                await connection.rollbackToSavepoint();
+
+                t.deepEqual(handlerInvoked, true);
+                t.deepEqual(commitInvoked, false);
+                t.deepEqual(rollbackInvoked, true);
             });
-            t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, false);
-            t.deepEqual(rollbackInvoked, false);
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -77,6 +82,10 @@ tape(__filename, async (t) => {
                                 testVal : BigInt(100),
                             },
                             {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
                                 testId : BigInt(3),
                                 testVal : BigInt(300),
                             },
@@ -84,9 +93,6 @@ tape(__filename, async (t) => {
                     );
                 });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-one/delete-one-in-savepoint-throw-error.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-one-in-savepoint-throw-error.ts
@@ -50,8 +50,7 @@ tape(__filename, async (t) => {
                 /**
                  * This should delete exactly one row.
                  */
-                await tsql.ExecutionUtil.deleteOne(
-                    dst,
+                await dst.deleteOne(
                     connection,
                     columns => tsql.eq(
                         columns.testVal,

--- a/test/run-time/input/connection/savepoint/delete-one/delete-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-one-in-transaction.ts
@@ -26,41 +26,14 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
-
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
-            });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
         await connection.transaction(async (connection) => {
-            await connection.savepoint(async (connection) => {
-                await dst.deleteOne(
-                    connection,
-                    columns => tsql.eq(
-                        columns.testVal,
-                        BigInt(200)
-                    )
-                );
-                t.deepEqual(handlerInvoked, true);
-                t.deepEqual(commitInvoked, false);
-                t.deepEqual(rollbackInvoked, false);
-            });
-            t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, false);
-            t.deepEqual(rollbackInvoked, false);
+            await dst.deleteOne(
+                connection,
+                columns => tsql.eq(
+                    columns.testVal,
+                    BigInt(200)
+                )
+            );
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -84,9 +57,28 @@ tape(__filename, async (t) => {
                     );
                 });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-one/delete-zero.ts
+++ b/test/run-time/input/connection/savepoint/delete-one/delete-zero.ts
@@ -33,8 +33,7 @@ tape(__filename, async (t) => {
              * which should rollback to savepoint,
              * causing no rows to be deleted
              */
-            await tsql.ExecutionUtil.deleteOne(
-                dst,
+            await dst.deleteOne(
                 connection,
                 columns => tsql.gt(
                     columns.testVal,

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-more-than-one-in-savepoint.ts
@@ -1,0 +1,79 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        return connection.transaction(async (connection) => {
+            return connection.savepoint(async (connection) => {
+                /**
+                 * This should end up deleting two rows,
+                 * which should throw an error,
+                 * which should rollback to savepoint,
+                 * causing no rows to be deleted
+                 */
+                await dst.deleteZeroOrOne(
+                    connection,
+                    columns => tsql.gt(
+                        columns.testVal,
+                        BigInt(100)
+                    )
+                ).then(() => {
+                    t.fail("Should not be able to delete two rows");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-more-than-one-in-transaction.ts
@@ -26,41 +26,24 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
-
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
+        return connection.transaction(async (connection) => {
+            /**
+             * This should end up deleting two rows,
+             * which should throw an error,
+             * which should rollback to savepoint,
+             * causing no rows to be deleted
+             */
+            await dst.deleteZeroOrOne(
+                connection,
+                columns => tsql.gt(
+                    columns.testVal,
+                    BigInt(100)
+                )
+            ).then(() => {
+                t.fail("Should not be able to delete two rows");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
             });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
-        await connection.transaction(async (connection) => {
-            await connection.savepoint(async (connection) => {
-                await dst.deleteOne(
-                    connection,
-                    columns => tsql.eq(
-                        columns.testVal,
-                        BigInt(200)
-                    )
-                );
-                t.deepEqual(handlerInvoked, true);
-                t.deepEqual(commitInvoked, false);
-                t.deepEqual(rollbackInvoked, false);
-            });
-            t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, false);
-            t.deepEqual(rollbackInvoked, false);
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -77,6 +60,10 @@ tape(__filename, async (t) => {
                                 testVal : BigInt(100),
                             },
                             {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
                                 testId : BigInt(3),
                                 testVal : BigInt(300),
                             },
@@ -84,9 +71,6 @@ tape(__filename, async (t) => {
                     );
                 });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-commit-2.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-commit-2.ts
@@ -47,7 +47,7 @@ tape(__filename, async (t) => {
 
         await connection.transaction(async (connection) => {
             await connection.savepoint(async (connection) => {
-                await dst.deleteOne(
+                await dst.deleteZeroOrOne(
                     connection,
                     columns => tsql.eq(
                         columns.testVal,
@@ -57,9 +57,22 @@ tape(__filename, async (t) => {
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, false);
+
+                await connection.releaseSavepoint();
+
+                t.deepEqual(handlerInvoked, true);
+                t.deepEqual(commitInvoked, false);
+                t.deepEqual(rollbackInvoked, false);
+
+                await connection.commit();
+
+                t.deepEqual(handlerInvoked, true);
+                t.deepEqual(commitInvoked, true);
+                t.deepEqual(rollbackInvoked, false);
+
             });
             t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, false);
+            t.deepEqual(commitInvoked, true);
             t.deepEqual(rollbackInvoked, false);
 
             await tsql.from(dst)

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-commit-5.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-commit-5.ts
@@ -47,19 +47,31 @@ tape(__filename, async (t) => {
 
         await connection.transaction(async (connection) => {
             await connection.savepoint(async (connection) => {
-                await dst.deleteOne(
-                    connection,
-                    columns => tsql.eq(
-                        columns.testVal,
-                        BigInt(200)
-                    )
-                );
+                await connection.savepoint(async (connection) => {
+                    await dst.deleteZeroOrOne(
+                        connection,
+                        columns => tsql.eq(
+                            columns.testVal,
+                            BigInt(200)
+                        )
+                    );
+                    t.deepEqual(handlerInvoked, true);
+                    t.deepEqual(commitInvoked, false);
+                    t.deepEqual(rollbackInvoked, false);
+                });
+
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, false);
             });
             t.deepEqual(handlerInvoked, true);
             t.deepEqual(commitInvoked, false);
+            t.deepEqual(rollbackInvoked, false);
+
+            await connection.commit();
+
+            t.deepEqual(handlerInvoked, true);
+            t.deepEqual(commitInvoked, true);
             t.deepEqual(rollbackInvoked, false);
 
             await tsql.from(dst)

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-commit.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-commit.ts
@@ -47,7 +47,7 @@ tape(__filename, async (t) => {
 
         await connection.transaction(async (connection) => {
             await connection.savepoint(async (connection) => {
-                await dst.deleteOne(
+                await dst.deleteZeroOrOne(
                     connection,
                     columns => tsql.eq(
                         columns.testVal,

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-nested-savepoint-rollback-after-parent-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-nested-savepoint-rollback-after-parent-savepoint.ts
@@ -26,29 +26,38 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
+        return connection.transaction(async (connection) => {
+            let handlerInvoked = false;
+            let commitInvoked = false;
+            let rollbackInvoked = false;
 
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
-            });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
-        await connection.transaction(async (connection) => {
+            /**
+             * This savepoint will be rolled back.
+             */
             await connection.savepoint(async (connection) => {
+                /**
+                 * This savepoint will be released.
+                 */
                 await connection.savepoint(async (connection) => {
-                    await dst.deleteOne(
+                    const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
+                        t.deepEqual(handlerInvoked, false);
+                        handlerInvoked = true;
+
+                        evt.addOnCommitListener(() => {
+                            t.fail("Should not invoke commit listener");
+                            commitInvoked = true;
+                        });
+
+                        evt.addOnRollbackListener(() => {
+                            t.deepEqual(rollbackInvoked, false);
+                            rollbackInvoked = true;
+                        });
+                    };
+                    pool.onDelete.addHandler(myDeleteHandler);
+                    /**
+                     * This should delete exactly one row.
+                     */
+                    await dst.deleteZeroOrOne(
                         connection,
                         columns => tsql.eq(
                             columns.testVal,
@@ -58,27 +67,13 @@ tape(__filename, async (t) => {
                     t.deepEqual(handlerInvoked, true);
                     t.deepEqual(commitInvoked, false);
                     t.deepEqual(rollbackInvoked, false);
-
-                    await connection.releaseSavepoint();
-
-                    t.deepEqual(handlerInvoked, true);
-                    t.deepEqual(commitInvoked, false);
-                    t.deepEqual(rollbackInvoked, false);
                 });
 
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, false);
 
-                await connection.commit();
-
-                t.deepEqual(handlerInvoked, true);
-                t.deepEqual(commitInvoked, true);
-                t.deepEqual(rollbackInvoked, false);
             });
-            t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, true);
-            t.deepEqual(rollbackInvoked, false);
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -101,10 +96,43 @@ tape(__filename, async (t) => {
                         ]
                     );
                 });
+
+            t.deepEqual(handlerInvoked, true);
+            t.deepEqual(commitInvoked, false);
+            t.deepEqual(rollbackInvoked, false);
+
+            await connection.rollback();
+
+            t.deepEqual(handlerInvoked, true);
+            t.deepEqual(commitInvoked, false);
+            t.deepEqual(rollbackInvoked, true);
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-nested-savepoint-rollback-to-savepoint-in-parent-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-nested-savepoint-rollback-to-savepoint-in-parent-savepoint.ts
@@ -57,8 +57,7 @@ tape(__filename, async (t) => {
                     /**
                      * This should delete exactly one row.
                      */
-                    await tsql.ExecutionUtil.deleteOne(
-                        dst,
+                    await dst.deleteZeroOrOne(
                         connection,
                         columns => tsql.eq(
                             columns.testVal,
@@ -68,14 +67,13 @@ tape(__filename, async (t) => {
                     t.deepEqual(handlerInvoked, true);
                     t.deepEqual(commitInvoked, false);
                     t.deepEqual(rollbackInvoked, false);
-
-                    await connection.rollback();
-
-                    t.deepEqual(handlerInvoked, true);
-                    t.deepEqual(commitInvoked, false);
-                    t.deepEqual(rollbackInvoked, true);
-
                 });
+
+                t.deepEqual(handlerInvoked, true);
+                t.deepEqual(commitInvoked, false);
+                t.deepEqual(rollbackInvoked, false);
+
+                await connection.rollbackToSavepoint();
 
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-nested-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-nested-savepoint-rollback.ts
@@ -26,29 +26,38 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
+        return connection.transaction(async (connection) => {
+            let handlerInvoked = false;
+            let commitInvoked = false;
+            let rollbackInvoked = false;
 
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
-            });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
-        await connection.transaction(async (connection) => {
+            /**
+             * This savepoint will be rolled back.
+             */
             await connection.savepoint(async (connection) => {
+                /**
+                 * This savepoint will be released.
+                 */
                 await connection.savepoint(async (connection) => {
-                    await dst.deleteOne(
+                    const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
+                        t.deepEqual(handlerInvoked, false);
+                        handlerInvoked = true;
+
+                        evt.addOnCommitListener(() => {
+                            t.fail("Should not invoke commit listener");
+                            commitInvoked = true;
+                        });
+
+                        evt.addOnRollbackListener(() => {
+                            t.deepEqual(rollbackInvoked, false);
+                            rollbackInvoked = true;
+                        });
+                    };
+                    pool.onDelete.addHandler(myDeleteHandler);
+                    /**
+                     * This should delete exactly one row.
+                     */
+                    await dst.deleteZeroOrOne(
                         connection,
                         columns => tsql.eq(
                             columns.testVal,
@@ -59,26 +68,23 @@ tape(__filename, async (t) => {
                     t.deepEqual(commitInvoked, false);
                     t.deepEqual(rollbackInvoked, false);
 
-                    await connection.releaseSavepoint();
+                    await connection.rollback();
 
                     t.deepEqual(handlerInvoked, true);
                     t.deepEqual(commitInvoked, false);
-                    t.deepEqual(rollbackInvoked, false);
+                    t.deepEqual(rollbackInvoked, true);
+
                 });
 
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
-                t.deepEqual(rollbackInvoked, false);
+                t.deepEqual(rollbackInvoked, true);
 
-                await connection.commit();
-
-                t.deepEqual(handlerInvoked, true);
-                t.deepEqual(commitInvoked, true);
-                t.deepEqual(rollbackInvoked, false);
             });
+
             t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, true);
-            t.deepEqual(rollbackInvoked, false);
+            t.deepEqual(commitInvoked, false);
+            t.deepEqual(rollbackInvoked, true);
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -95,6 +101,10 @@ tape(__filename, async (t) => {
                                 testVal : BigInt(100),
                             },
                             {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
                                 testId : BigInt(3),
                                 testVal : BigInt(300),
                             },
@@ -102,9 +112,6 @@ tape(__filename, async (t) => {
                     );
                 });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-nested-savepoint-throw-error-in-parent-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-nested-savepoint-throw-error-in-parent-savepoint.ts
@@ -27,46 +27,65 @@ tape(__filename, async (t) => {
         `);
 
         return connection.transaction(async (connection) => {
+            let handlerInvoked = false;
+            let commitInvoked = false;
+            let rollbackInvoked = false;
+
+            /**
+             * This savepoint will be rolled back.
+             */
             await connection.savepoint(async (connection) => {
-                let handlerInvoked = false;
-                let commitInvoked = false;
-                let rollbackInvoked = false;
-                const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-                    t.deepEqual(handlerInvoked, false);
-                    handlerInvoked = true;
-
-                    evt.addOnCommitListener(() => {
-                        t.fail("Should not invoke commit listener");
-                        commitInvoked = true;
-                    });
-
-                    evt.addOnRollbackListener(() => {
-                        t.deepEqual(rollbackInvoked, false);
-                        rollbackInvoked = true;
-                    });
-                };
-                pool.onDelete.addHandler(myDeleteHandler);
                 /**
-                 * This should delete exactly one row.
+                 * This savepoint will be released.
                  */
-                await tsql.ExecutionUtil.deleteOne(
-                    dst,
-                    connection,
-                    columns => tsql.eq(
-                        columns.testVal,
-                        BigInt(200)
-                    )
-                );
+                await connection.savepoint(async (connection) => {
+                    const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
+                        t.deepEqual(handlerInvoked, false);
+                        handlerInvoked = true;
+
+                        evt.addOnCommitListener(() => {
+                            t.fail("Should not invoke commit listener");
+                            commitInvoked = true;
+                        });
+
+                        evt.addOnRollbackListener(() => {
+                            t.deepEqual(rollbackInvoked, false);
+                            rollbackInvoked = true;
+                        });
+                    };
+                    pool.onDelete.addHandler(myDeleteHandler);
+                    /**
+                     * This should delete exactly one row.
+                     */
+                    await dst.deleteZeroOrOne(
+                        connection,
+                        columns => tsql.eq(
+                            columns.testVal,
+                            BigInt(200)
+                        )
+                    );
+                    t.deepEqual(handlerInvoked, true);
+                    t.deepEqual(commitInvoked, false);
+                    t.deepEqual(rollbackInvoked, false);
+                });
+
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, false);
 
-                await connection.rollbackToSavepoint();
+                throw new Error(`Blah`);
+            }).catch((err) => {
 
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, true);
+
+                t.deepEqual(err.message, `Blah`);
             });
+
+            t.deepEqual(handlerInvoked, true);
+            t.deepEqual(commitInvoked, false);
+            t.deepEqual(rollbackInvoked, true);
 
             await tsql.from(dst)
                 .select(columns => [columns])

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-savepoint-rollback-to-savepoint.ts
@@ -26,28 +26,30 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
-
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
-            });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
-        await connection.transaction(async (connection) => {
+        return connection.transaction(async (connection) => {
             await connection.savepoint(async (connection) => {
-                await dst.deleteOne(
+                let handlerInvoked = false;
+                let commitInvoked = false;
+                let rollbackInvoked = false;
+                const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
+                    t.deepEqual(handlerInvoked, false);
+                    handlerInvoked = true;
+
+                    evt.addOnCommitListener(() => {
+                        t.fail("Should not invoke commit listener");
+                        commitInvoked = true;
+                    });
+
+                    evt.addOnRollbackListener(() => {
+                        t.deepEqual(rollbackInvoked, false);
+                        rollbackInvoked = true;
+                    });
+                };
+                pool.onDelete.addHandler(myDeleteHandler);
+                /**
+                 * This should delete exactly one row.
+                 */
+                await dst.deleteZeroOrOne(
                     connection,
                     columns => tsql.eq(
                         columns.testVal,
@@ -57,10 +59,13 @@ tape(__filename, async (t) => {
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, false);
+
+                await connection.rollbackToSavepoint();
+
+                t.deepEqual(handlerInvoked, true);
+                t.deepEqual(commitInvoked, false);
+                t.deepEqual(rollbackInvoked, true);
             });
-            t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, false);
-            t.deepEqual(rollbackInvoked, false);
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -77,6 +82,10 @@ tape(__filename, async (t) => {
                                 testVal : BigInt(100),
                             },
                             {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
                                 testId : BigInt(3),
                                 testVal : BigInt(300),
                             },
@@ -84,9 +93,6 @@ tape(__filename, async (t) => {
                     );
                 });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-savepoint-throw-error.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-savepoint-throw-error.ts
@@ -26,28 +26,31 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
+        return connection.transaction(async (connection) => {
+            let handlerInvoked = false;
+            let commitInvoked = false;
+            let rollbackInvoked = false;
 
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
-            });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
-        await connection.transaction(async (connection) => {
             await connection.savepoint(async (connection) => {
-                await dst.deleteOne(
+                const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
+                    t.deepEqual(handlerInvoked, false);
+                    handlerInvoked = true;
+
+                    evt.addOnCommitListener(() => {
+                        t.fail("Should not invoke commit listener");
+                        commitInvoked = true;
+                    });
+
+                    evt.addOnRollbackListener(() => {
+                        t.deepEqual(rollbackInvoked, false);
+                        rollbackInvoked = true;
+                    });
+                };
+                pool.onDelete.addHandler(myDeleteHandler);
+                /**
+                 * This should delete exactly one row.
+                 */
+                await dst.deleteZeroOrOne(
                     connection,
                     columns => tsql.eq(
                         columns.testVal,
@@ -57,10 +60,20 @@ tape(__filename, async (t) => {
                 t.deepEqual(handlerInvoked, true);
                 t.deepEqual(commitInvoked, false);
                 t.deepEqual(rollbackInvoked, false);
+
+                throw new Error(`Blah`);
+            }).catch((err) => {
+
+                t.deepEqual(handlerInvoked, true);
+                t.deepEqual(commitInvoked, false);
+                t.deepEqual(rollbackInvoked, true);
+
+                t.deepEqual(err.message, `Blah`);
             });
+
             t.deepEqual(handlerInvoked, true);
             t.deepEqual(commitInvoked, false);
-            t.deepEqual(rollbackInvoked, false);
+            t.deepEqual(rollbackInvoked, true);
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -77,6 +90,10 @@ tape(__filename, async (t) => {
                                 testVal : BigInt(100),
                             },
                             {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
                                 testId : BigInt(3),
                                 testVal : BigInt(300),
                             },
@@ -84,9 +101,6 @@ tape(__filename, async (t) => {
                     );
                 });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-savepoint.ts
@@ -26,13 +26,39 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        await dst.deleteOne(
-            connection,
-            columns => tsql.eq(
-                columns.testVal,
-                BigInt(200)
-            )
-        );
+        await connection.transaction(async (connection) => {
+            return connection.savepoint(async (connection) => {
+                await dst.deleteZeroOrOne(
+                    connection,
+                    columns => tsql.eq(
+                        columns.testVal,
+                        BigInt(200)
+                    )
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
 
         await tsql.from(dst)
             .select(columns => [columns])

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one-in-transaction.ts
@@ -26,41 +26,14 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        let handlerInvoked = false;
-        let commitInvoked = false;
-        let rollbackInvoked = false;
-        const myDeleteHandler : tsql.EventHandler<tsql.IDeleteEvent<tsql.ITable>> = (evt) => {
-            t.deepEqual(handlerInvoked, false);
-            handlerInvoked = true;
-
-            evt.addOnCommitListener(() => {
-                t.deepEqual(commitInvoked, false);
-                commitInvoked = true;
-            });
-
-            evt.addOnRollbackListener(() => {
-                t.fail("Should not invoke rollback listener");
-                rollbackInvoked = true;
-            });
-        };
-        pool.onDelete.addHandler(myDeleteHandler);
-
         await connection.transaction(async (connection) => {
-            await connection.savepoint(async (connection) => {
-                await dst.deleteOne(
-                    connection,
-                    columns => tsql.eq(
-                        columns.testVal,
-                        BigInt(200)
-                    )
-                );
-                t.deepEqual(handlerInvoked, true);
-                t.deepEqual(commitInvoked, false);
-                t.deepEqual(rollbackInvoked, false);
-            });
-            t.deepEqual(handlerInvoked, true);
-            t.deepEqual(commitInvoked, false);
-            t.deepEqual(rollbackInvoked, false);
+            await dst.deleteZeroOrOne(
+                connection,
+                columns => tsql.eq(
+                    columns.testVal,
+                    BigInt(200)
+                )
+            );
 
             await tsql.from(dst)
                 .select(columns => [columns])
@@ -84,9 +57,28 @@ tape(__filename, async (t) => {
                     );
                 });
         });
-        t.deepEqual(handlerInvoked, true);
-        t.deepEqual(commitInvoked, true);
-        t.deepEqual(rollbackInvoked, false);
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
     });
 
     t.end();

--- a/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one.ts
+++ b/test/run-time/input/connection/savepoint/delete-zero-or-one/delete-one.ts
@@ -26,7 +26,7 @@ tape(__filename, async (t) => {
                 (3,300);
         `);
 
-        await dst.deleteOne(
+        await dst.deleteZeroOrOne(
             connection,
             columns => tsql.eq(
                 columns.testVal,

--- a/test/run-time/input/connection/savepoint/insert-and-fetch/fetch-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/insert-and-fetch/fetch-more-than-one-in-savepoint.ts
@@ -1,0 +1,82 @@
+import * as tm from "type-mapping";
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const test = tsql.table("test")
+        .addColumns({
+            testId : tm.mysql.bigIntUnsigned(),
+            testVal : tm.mysql.bigIntUnsigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+
+
+    await pool.acquire(async (connection) => {
+        await connection.exec(`
+            CREATE TABLE test (
+                testId INT,
+                testVal INT
+            );
+            INSERT INTO
+                test(testId, testVal)
+            VALUES
+                (1, 100),
+                (2, 200),
+                (3, 300),
+                (4, 444);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await test.insertAndFetch(
+                    connection,
+                    {
+                        testId : BigInt(4),
+                        testVal : BigInt(400),
+                    }
+                ).then(() => {
+                    t.fail("Should not be able to fetch more than one row");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                await tsql.from(test)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((result) => {
+                        t.deepEqual(
+                            result,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                                {
+                                    testId : BigInt(4),
+                                    testVal : BigInt(444),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/insert-and-fetch/fetch-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/insert-and-fetch/fetch-more-than-one-in-transaction.ts
@@ -1,0 +1,80 @@
+import * as tm from "type-mapping";
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const test = tsql.table("test")
+        .addColumns({
+            testId : tm.mysql.bigIntUnsigned(),
+            testVal : tm.mysql.bigIntUnsigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+
+
+    await pool.acquire(async (connection) => {
+        await connection.exec(`
+            CREATE TABLE test (
+                testId INT,
+                testVal INT
+            );
+            INSERT INTO
+                test(testId, testVal)
+            VALUES
+                (1, 100),
+                (2, 200),
+                (3, 300),
+                (4, 444);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await test.insertAndFetch(
+                connection,
+                {
+                    testId : BigInt(4),
+                    testVal : BigInt(400),
+                }
+            ).then(() => {
+                t.fail("Should not be able to fetch more than one row");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            await tsql.from(test)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((result) => {
+                    t.deepEqual(
+                        result,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                            {
+                                testId : BigInt(4),
+                                testVal : BigInt(444),
+                            },
+                        ]
+                    );
+                });
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/insert-and-fetch/fetch-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/insert-and-fetch/fetch-more-than-one.ts
@@ -1,0 +1,78 @@
+import * as tm from "type-mapping";
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const test = tsql.table("test")
+        .addColumns({
+            testId : tm.mysql.bigIntUnsigned(),
+            testVal : tm.mysql.bigIntUnsigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+
+
+    await pool.acquire(async (connection) => {
+        await connection.exec(`
+            CREATE TABLE test (
+                testId INT,
+                testVal INT
+            );
+            INSERT INTO
+                test(testId, testVal)
+            VALUES
+                (1, 100),
+                (2, 200),
+                (3, 300),
+                (4, 444);
+        `);
+
+        await test.insertAndFetch(
+            connection,
+            {
+                testId : BigInt(4),
+                testVal : BigInt(400),
+            }
+        ).then(() => {
+            t.fail("Should not be able to fetch more than one row");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        await tsql.from(test)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((result) => {
+                t.deepEqual(
+                    result,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                        {
+                            testId : BigInt(4),
+                            testVal : BigInt(444),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-savepoint-rollback-to-savepoint.ts
@@ -1,0 +1,131 @@
+import * as tm from "type-mapping";
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const test = tsql.table("test")
+        .addColumns({
+            testId : tm.mysql.bigIntUnsigned(),
+            testVal : tm.mysql.bigIntUnsigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+
+
+    await pool.acquire(async (connection) => {
+        await connection.exec(`
+            CREATE TABLE test (
+                testId INT,
+                testVal INT
+            );
+            INSERT INTO
+                test(testId, testVal)
+            VALUES
+                (1, 100),
+                (2, 200),
+                (3, 300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await test.insertAndFetch(
+                    connection,
+                    {
+                        testId : BigInt(4),
+                        testVal : BigInt(400),
+                    }
+                );
+
+                await tsql.from(test)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((result) => {
+                        t.deepEqual(
+                            result,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                                {
+                                    testId : BigInt(4),
+                                    testVal : BigInt(400),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollbackToSavepoint();
+
+                await tsql.from(test)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((result) => {
+                        t.deepEqual(
+                            result,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(test)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((result) => {
+                t.deepEqual(
+                    result,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-savepoint-rollback.ts
@@ -1,0 +1,131 @@
+import * as tm from "type-mapping";
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const test = tsql.table("test")
+        .addColumns({
+            testId : tm.mysql.bigIntUnsigned(),
+            testVal : tm.mysql.bigIntUnsigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+
+
+    await pool.acquire(async (connection) => {
+        await connection.exec(`
+            CREATE TABLE test (
+                testId INT,
+                testVal INT
+            );
+            INSERT INTO
+                test(testId, testVal)
+            VALUES
+                (1, 100),
+                (2, 200),
+                (3, 300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await test.insertAndFetch(
+                    connection,
+                    {
+                        testId : BigInt(4),
+                        testVal : BigInt(400),
+                    }
+                );
+
+                await tsql.from(test)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((result) => {
+                        t.deepEqual(
+                            result,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                                {
+                                    testId : BigInt(4),
+                                    testVal : BigInt(400),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollback();
+
+                await tsql.from(test)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((result) => {
+                        t.deepEqual(
+                            result,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(test)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((result) => {
+                t.deepEqual(
+                    result,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-savepoint.ts
@@ -1,0 +1,107 @@
+import * as tm from "type-mapping";
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const test = tsql.table("test")
+        .addColumns({
+            testId : tm.mysql.bigIntUnsigned(),
+            testVal : tm.mysql.bigIntUnsigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+
+
+    await pool.acquire(async (connection) => {
+        await connection.exec(`
+            CREATE TABLE test (
+                testId INT,
+                testVal INT
+            );
+            INSERT INTO
+                test(testId, testVal)
+            VALUES
+                (1, 100),
+                (2, 200),
+                (3, 300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await test.insertAndFetch(
+                    connection,
+                    {
+                        testId : BigInt(4),
+                        testVal : BigInt(400),
+                    }
+                );
+
+                await tsql.from(test)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((result) => {
+                        t.deepEqual(
+                            result,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                                {
+                                    testId : BigInt(4),
+                                    testVal : BigInt(400),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(test)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((result) => {
+                t.deepEqual(
+                    result,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                        {
+                            testId : BigInt(4),
+                            testVal : BigInt(400),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-transaction-rollback.ts
+++ b/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-transaction-rollback.ts
@@ -1,0 +1,129 @@
+import * as tm from "type-mapping";
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const test = tsql.table("test")
+        .addColumns({
+            testId : tm.mysql.bigIntUnsigned(),
+            testVal : tm.mysql.bigIntUnsigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+
+
+    await pool.acquire(async (connection) => {
+        await connection.exec(`
+            CREATE TABLE test (
+                testId INT,
+                testVal INT
+            );
+            INSERT INTO
+                test(testId, testVal)
+            VALUES
+                (1, 100),
+                (2, 200),
+                (3, 300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await test.insertAndFetch(
+                connection,
+                {
+                    testId : BigInt(4),
+                    testVal : BigInt(400),
+                }
+            );
+
+            await tsql.from(test)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((result) => {
+                    t.deepEqual(
+                        result,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                            {
+                                testId : BigInt(4),
+                                testVal : BigInt(400),
+                            },
+                        ]
+                    );
+                });
+
+            await connection.rollback();
+
+            await tsql.from(test)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((result) => {
+                    t.deepEqual(
+                        result,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(test)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((result) => {
+                t.deepEqual(
+                    result,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one-in-transaction.ts
@@ -1,0 +1,105 @@
+import * as tm from "type-mapping";
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const test = tsql.table("test")
+        .addColumns({
+            testId : tm.mysql.bigIntUnsigned(),
+            testVal : tm.mysql.bigIntUnsigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+
+
+    await pool.acquire(async (connection) => {
+        await connection.exec(`
+            CREATE TABLE test (
+                testId INT,
+                testVal INT
+            );
+            INSERT INTO
+                test(testId, testVal)
+            VALUES
+                (1, 100),
+                (2, 200),
+                (3, 300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await test.insertAndFetch(
+                connection,
+                {
+                    testId : BigInt(4),
+                    testVal : BigInt(400),
+                }
+            );
+
+            await tsql.from(test)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((result) => {
+                    t.deepEqual(
+                        result,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                            {
+                                testId : BigInt(4),
+                                testVal : BigInt(400),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(test)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((result) => {
+                t.deepEqual(
+                    result,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                        {
+                            testId : BigInt(4),
+                            testVal : BigInt(400),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one.ts
+++ b/test/run-time/input/connection/savepoint/insert-and-fetch/insert-one.ts
@@ -1,0 +1,73 @@
+import * as tm from "type-mapping";
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const test = tsql.table("test")
+        .addColumns({
+            testId : tm.mysql.bigIntUnsigned(),
+            testVal : tm.mysql.bigIntUnsigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId]);
+
+
+
+    await pool.acquire(async (connection) => {
+        await connection.exec(`
+            CREATE TABLE test (
+                testId INT,
+                testVal INT
+            );
+            INSERT INTO
+                test(testId, testVal)
+            VALUES
+                (1, 100),
+                (2, 200),
+                (3, 300);
+        `);
+
+        await test.insertAndFetch(
+            connection,
+            {
+                testId : BigInt(4),
+                testVal : BigInt(400),
+            }
+        );
+
+        await tsql.from(test)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((result) => {
+                t.deepEqual(
+                    result,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                        {
+                            testId : BigInt(4),
+                            testVal : BigInt(400),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/fetch-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/fetch-more-than-one-in-savepoint.ts
@@ -1,0 +1,115 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt, serverAppKey, appKey} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            if (!evt.isFor(appKey)) {
+                if (evt.isFor(serverAppKey)) {
+                    t.deepEqual(handlerInvoked, 1);
+                } else {
+                    t.fail("Should only be invoked for appKey or serverAppKey");
+                }
+                return;
+            }
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(rollbackInvoked, 0);
+                ++rollbackInvoked;
+            });
+
+            await serverAppKey.insertAndFetch(
+                evt.connection,
+                {
+                    appKeyId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.insertAndFetch(
+                    connection,
+                    {
+                        appId : BigInt(1),
+                        key : "server",
+                        createdAt : new Date(1),
+                        disabledAt : new Date(2),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                    }
+                ).then(() => {
+                    t.fail("Should not fetch more than one row");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 1);
+
+                await specialServerAppKey.existsByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId : BigInt(1),
+                    }
+                ).then((result) => {
+                    t.deepEqual(result, false);
+                });
+            });
+
+            t.deepEqual(handlerInvoked, 1);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 1);
+
+        });
+
+        t.deepEqual(handlerInvoked, 1);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 1);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, false);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/fetch-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/fetch-more-than-one-in-transaction.ts
@@ -1,0 +1,109 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt, serverAppKey, appKey} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            if (!evt.isFor(appKey)) {
+                if (evt.isFor(serverAppKey)) {
+                    t.deepEqual(handlerInvoked, 1);
+                } else {
+                    t.fail("Should only be invoked for appKey or serverAppKey");
+                }
+                return;
+            }
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(rollbackInvoked, 0);
+                ++rollbackInvoked;
+            });
+
+            await serverAppKey.insertAndFetch(
+                evt.connection,
+                {
+                    appKeyId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await specialServerAppKeyTpt.insertAndFetch(
+                connection,
+                {
+                    appId : BigInt(1),
+                    key : "server",
+                    createdAt : new Date(1),
+                    disabledAt : new Date(2),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                }
+            ).then(() => {
+                t.fail("Should not fetch more than one row");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            t.deepEqual(handlerInvoked, 1);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 1);
+
+            await specialServerAppKey.existsByPrimaryKey(
+                connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            ).then((result) => {
+                t.deepEqual(result, false);
+            });
+
+        });
+
+        t.deepEqual(handlerInvoked, 1);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 1);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, false);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/fetch-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/fetch-more-than-one.ts
@@ -1,0 +1,93 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt, serverAppKey, appKey} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            if (!evt.isFor(appKey)) {
+                if (evt.isFor(serverAppKey)) {
+                    t.deepEqual(handlerInvoked, 1);
+                } else {
+                    t.fail("Should only be invoked for appKey or serverAppKey");
+                }
+                return;
+            }
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(rollbackInvoked, 0);
+                ++rollbackInvoked;
+            });
+
+            await serverAppKey.insertAndFetch(
+                evt.connection,
+                {
+                    appKeyId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then(() => {
+            t.fail("Should not fetch more than one row");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        t.deepEqual(handlerInvoked, 1);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 1);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, false);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-savepoint-rollback-to-savepoint.ts
@@ -1,0 +1,131 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                ++rollbackInvoked;
+            });
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.insertAndFetch(
+                    connection,
+                    {
+                        appId : BigInt(1),
+                        key : "server",
+                        createdAt : new Date(1),
+                        disabledAt : new Date(2),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                    }
+                ).then((insertResult) => {
+                    t.deepEqual(
+                        insertResult,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 0);
+
+                await specialServerAppKey.existsByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId : BigInt(1),
+                    }
+                ).then((result) => {
+                    t.deepEqual(result, true);
+                });
+
+                await connection.rollbackToSavepoint();
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 3);
+
+                await specialServerAppKey.existsByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId : BigInt(1),
+                    }
+                ).then((result) => {
+                    t.deepEqual(result, false);
+                });
+            });
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 3);
+
+            await specialServerAppKey.existsByPrimaryKey(
+                connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            ).then((result) => {
+                t.deepEqual(result, false);
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 3);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, false);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-savepoint-rollback.ts
@@ -1,0 +1,131 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                ++rollbackInvoked;
+            });
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.insertAndFetch(
+                    connection,
+                    {
+                        appId : BigInt(1),
+                        key : "server",
+                        createdAt : new Date(1),
+                        disabledAt : new Date(2),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                    }
+                ).then((insertResult) => {
+                    t.deepEqual(
+                        insertResult,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 0);
+
+                await specialServerAppKey.existsByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId : BigInt(1),
+                    }
+                ).then((result) => {
+                    t.deepEqual(result, true);
+                });
+
+                await connection.rollback();
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 3);
+
+                await specialServerAppKey.existsByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId : BigInt(1),
+                    }
+                ).then((result) => {
+                    t.deepEqual(result, false);
+                });
+            });
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 3);
+
+            await specialServerAppKey.existsByPrimaryKey(
+                connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            ).then((result) => {
+                t.deepEqual(result, false);
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 3);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, false);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-savepoint.ts
@@ -1,0 +1,107 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(rollbackInvoked, 0);
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.fail("Should not invoke rollback listener");
+                ++rollbackInvoked;
+            });
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.insertAndFetch(
+                    connection,
+                    {
+                        appId : BigInt(1),
+                        key : "server",
+                        createdAt : new Date(1),
+                        disabledAt : new Date(2),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                    }
+                ).then((insertResult) => {
+                    t.deepEqual(
+                        insertResult,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 0);
+
+                await specialServerAppKey.existsByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId : BigInt(1),
+                    }
+                ).then((result) => {
+                    t.deepEqual(result, true);
+                });
+            });
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 0);
+
+        });
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 3);
+        t.deepEqual(rollbackInvoked, 0);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, true);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-transaction-rollback.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-transaction-rollback.ts
@@ -1,0 +1,116 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                ++rollbackInvoked;
+            });
+        });
+
+        await connection.transaction(async (connection) => {
+            await specialServerAppKeyTpt.insertAndFetch(
+                connection,
+                {
+                    appId : BigInt(1),
+                    key : "server",
+                    createdAt : new Date(1),
+                    disabledAt : new Date(2),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                }
+            ).then((insertResult) => {
+                t.deepEqual(
+                    insertResult,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 0);
+
+            await specialServerAppKey.existsByPrimaryKey(
+                connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            ).then((result) => {
+                t.deepEqual(result, true);
+            });
+
+            await connection.rollback();
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 3);
+
+            await specialServerAppKey.existsByPrimaryKey(
+                connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            ).then((result) => {
+                t.deepEqual(result, false);
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 3);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, false);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one-in-transaction.ts
@@ -1,0 +1,100 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(rollbackInvoked, 0);
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.fail("Should not invoke rollback listener");
+                ++rollbackInvoked;
+            });
+        });
+
+        await connection.transaction(async (connection) => {
+            await specialServerAppKeyTpt.insertAndFetch(
+                connection,
+                {
+                    appId : BigInt(1),
+                    key : "server",
+                    createdAt : new Date(1),
+                    disabledAt : new Date(2),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                }
+            ).then((insertResult) => {
+                t.deepEqual(
+                    insertResult,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 0);
+
+            await specialServerAppKey.existsByPrimaryKey(
+                connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            ).then((result) => {
+                t.deepEqual(result, true);
+            });
+        });
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 3);
+        t.deepEqual(rollbackInvoked, 0);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, true);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/insert-and-fetch/insert-one.ts
@@ -1,0 +1,86 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(rollbackInvoked, 0);
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.fail("Should not invoke rollback listener");
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 3);
+        t.deepEqual(rollbackInvoked, 0);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, true);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/fetch-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/fetch-more-than-one-in-savepoint.ts
@@ -1,0 +1,164 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt, serverAppKey} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            if (!evt.isFor(specialServerAppKey)) {
+                if (evt.isFor(serverAppKey)) {
+                    t.deepEqual(handlerInvoked, 1);
+                } else {
+                    t.fail("Should only be invoked for specialServerAppKey or serverAppKey");
+                }
+                return;
+            }
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(rollbackInvoked, 0);
+                ++rollbackInvoked;
+            });
+
+            /**
+             * This will cause the next `updateAndFetchOne()` to update
+             * two rows, and throw an error.
+             */
+            await serverAppKey.insertOne(
+                evt.connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.updateAndFetchOneByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId: BigInt(1),
+                    },
+                    () => {
+                        return {
+                            ipAddress : "ip-updated",
+                        };
+                    }
+                ).then(() => {
+                    t.fail("Should not succeed");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 1);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+            });
+        });
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/fetch-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/fetch-more-than-one-in-transaction.ts
@@ -1,0 +1,162 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt, serverAppKey} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            if (!evt.isFor(specialServerAppKey)) {
+                if (evt.isFor(serverAppKey)) {
+                    t.deepEqual(handlerInvoked, 1);
+                } else {
+                    t.fail("Should only be invoked for specialServerAppKey or serverAppKey");
+                }
+                return;
+            }
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(rollbackInvoked, 0);
+                ++rollbackInvoked;
+            });
+
+            /**
+             * This will cause the next `updateAndFetchOne()` to update
+             * two rows, and throw an error.
+             */
+            await serverAppKey.insertOne(
+                evt.connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await specialServerAppKeyTpt.updateAndFetchOneByPrimaryKey(
+                connection,
+                {
+                    appKeyId: BigInt(1),
+                },
+                () => {
+                    return {
+                        ipAddress : "ip-updated",
+                    };
+                }
+            ).then(() => {
+                t.fail("Should not succeed");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            t.deepEqual(handlerInvoked, 1);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 1);
+
+            await specialServerAppKeyTpt.fetchOne(
+                connection,
+                () => tsql.eqPrimaryKey(
+                    specialServerAppKey,
+                    {
+                        appKeyId: BigInt(1),
+                    }
+                )
+            ).then((result) => {
+                t.deepEqual(
+                    result,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+        });
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/fetch-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/fetch-more-than-one.ts
@@ -1,0 +1,136 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt, serverAppKey} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            if (!evt.isFor(specialServerAppKey)) {
+                if (evt.isFor(serverAppKey)) {
+                    t.deepEqual(handlerInvoked, 1);
+                } else {
+                    t.fail("Should only be invoked for specialServerAppKey or serverAppKey");
+                }
+                return;
+            }
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(rollbackInvoked, 0);
+                ++rollbackInvoked;
+            });
+
+            /**
+             * This will cause the next `updateAndFetchOne()` to update
+             * two rows, and throw an error.
+             */
+            await serverAppKey.insertOne(
+                evt.connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.updateAndFetchOneByPrimaryKey(
+            connection,
+            {
+                appKeyId: BigInt(1),
+            },
+            () => {
+                return {
+                    ipAddress : "ip-updated",
+                };
+            }
+        ).then(() => {
+            t.fail("Should not succeed");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        t.deepEqual(handlerInvoked, 1);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 1);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-savepoint-rollback-to-savepoint.ts
@@ -1,0 +1,175 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.updateAndFetchOneByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId: BigInt(1),
+                    },
+                    () => {
+                        return {
+                            ipAddress : "ip-updated",
+                        };
+                    }
+                );
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 0);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip-updated",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+
+                await connection.rollbackToSavepoint();
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 3);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 3);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-savepoint-rollback.ts
@@ -1,0 +1,175 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.updateAndFetchOneByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId: BigInt(1),
+                    },
+                    () => {
+                        return {
+                            ipAddress : "ip-updated",
+                        };
+                    }
+                );
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 0);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip-updated",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+
+                await connection.rollback();
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 3);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 3);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-savepoint.ts
@@ -1,0 +1,145 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(rollbackInvoked, 0);
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.fail("Should not invoke rollback listener");
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.updateAndFetchOneByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId: BigInt(1),
+                    },
+                    () => {
+                        return {
+                            ipAddress : "ip-updated",
+                        };
+                    }
+                );
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 0);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip-updated",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 3);
+        t.deepEqual(rollbackInvoked, 0);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip-updated",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-transaction-rollback.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-transaction-rollback.ts
@@ -1,0 +1,173 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await specialServerAppKeyTpt.updateAndFetchOneByPrimaryKey(
+                connection,
+                {
+                    appKeyId: BigInt(1),
+                },
+                () => {
+                    return {
+                        ipAddress : "ip-updated",
+                    };
+                }
+            );
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 0);
+
+            await specialServerAppKeyTpt.fetchOne(
+                connection,
+                () => tsql.eqPrimaryKey(
+                    specialServerAppKey,
+                    {
+                        appKeyId: BigInt(1),
+                    }
+                )
+            ).then((result) => {
+                t.deepEqual(
+                    result,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip-updated",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+
+            await connection.rollback();
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 3);
+
+            await specialServerAppKeyTpt.fetchOne(
+                connection,
+                () => tsql.eqPrimaryKey(
+                    specialServerAppKey,
+                    {
+                        appKeyId: BigInt(1),
+                    }
+                )
+            ).then((result) => {
+                t.deepEqual(
+                    result,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 3);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one-in-transaction.ts
@@ -1,0 +1,143 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(rollbackInvoked, 0);
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.fail("Should not invoke rollback listener");
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await specialServerAppKeyTpt.updateAndFetchOneByPrimaryKey(
+                connection,
+                {
+                    appKeyId: BigInt(1),
+                },
+                () => {
+                    return {
+                        ipAddress : "ip-updated",
+                    };
+                }
+            );
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 0);
+
+            await specialServerAppKeyTpt.fetchOne(
+                connection,
+                () => tsql.eqPrimaryKey(
+                    specialServerAppKey,
+                    {
+                        appKeyId: BigInt(1),
+                    }
+                )
+            ).then((result) => {
+                t.deepEqual(
+                    result,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip-updated",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 3);
+        t.deepEqual(rollbackInvoked, 0);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip-updated",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-one/update-one.ts
@@ -27,7 +27,7 @@ tape(__filename, async (t) => {
         let handlerInvoked = 0;
         let commitInvoked = 0;
         let rollbackInvoked = 0;
-        pool.onInsertAndFetch.addHandler(async (evt) => {
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
             ++handlerInvoked;
 
             evt.addOnCommitListener(() => {
@@ -84,13 +84,28 @@ tape(__filename, async (t) => {
         t.deepEqual(commitInvoked, 3);
         t.deepEqual(rollbackInvoked, 0);
 
-        await specialServerAppKey.existsByPrimaryKey(
+        await specialServerAppKeyTpt.fetchOne(
             connection,
-            {
-                appKeyId : BigInt(1),
-            }
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
         ).then((result) => {
-            t.deepEqual(result, true);
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip-updated",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
         });
     });
 

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/fetch-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/fetch-more-than-one-in-savepoint.ts
@@ -1,0 +1,164 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt, serverAppKey} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            if (!evt.isFor(specialServerAppKey)) {
+                if (evt.isFor(serverAppKey)) {
+                    t.deepEqual(handlerInvoked, 1);
+                } else {
+                    t.fail("Should only be invoked for specialServerAppKey or serverAppKey");
+                }
+                return;
+            }
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(rollbackInvoked, 0);
+                ++rollbackInvoked;
+            });
+
+            /**
+             * This will cause the next `updateAndFetchZeroOrOne()` to update
+             * two rows, and throw an error.
+             */
+            await serverAppKey.insertOne(
+                evt.connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.updateAndFetchZeroOrOneByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId: BigInt(1),
+                    },
+                    () => {
+                        return {
+                            ipAddress : "ip-updated",
+                        };
+                    }
+                ).then(() => {
+                    t.fail("Should not succeed");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 1);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+            });
+        });
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/fetch-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/fetch-more-than-one-in-transaction.ts
@@ -1,0 +1,162 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt, serverAppKey} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            if (!evt.isFor(specialServerAppKey)) {
+                if (evt.isFor(serverAppKey)) {
+                    t.deepEqual(handlerInvoked, 1);
+                } else {
+                    t.fail("Should only be invoked for specialServerAppKey or serverAppKey");
+                }
+                return;
+            }
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(rollbackInvoked, 0);
+                ++rollbackInvoked;
+            });
+
+            /**
+             * This will cause the next `updateAndFetchZeroOrOne()` to update
+             * two rows, and throw an error.
+             */
+            await serverAppKey.insertOne(
+                evt.connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await specialServerAppKeyTpt.updateAndFetchZeroOrOneByPrimaryKey(
+                connection,
+                {
+                    appKeyId: BigInt(1),
+                },
+                () => {
+                    return {
+                        ipAddress : "ip-updated",
+                    };
+                }
+            ).then(() => {
+                t.fail("Should not succeed");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            t.deepEqual(handlerInvoked, 1);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 1);
+
+            await specialServerAppKeyTpt.fetchOne(
+                connection,
+                () => tsql.eqPrimaryKey(
+                    specialServerAppKey,
+                    {
+                        appKeyId: BigInt(1),
+                    }
+                )
+            ).then((result) => {
+                t.deepEqual(
+                    result,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+        });
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/fetch-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/fetch-more-than-one.ts
@@ -1,0 +1,136 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt, serverAppKey} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            if (!evt.isFor(specialServerAppKey)) {
+                if (evt.isFor(serverAppKey)) {
+                    t.deepEqual(handlerInvoked, 1);
+                } else {
+                    t.fail("Should only be invoked for specialServerAppKey or serverAppKey");
+                }
+                return;
+            }
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 1);
+                t.deepEqual(rollbackInvoked, 0);
+                ++rollbackInvoked;
+            });
+
+            /**
+             * This will cause the next `updateAndFetchZeroOrOne()` to update
+             * two rows, and throw an error.
+             */
+            await serverAppKey.insertOne(
+                evt.connection,
+                {
+                    appKeyId : BigInt(1),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.updateAndFetchZeroOrOneByPrimaryKey(
+            connection,
+            {
+                appKeyId: BigInt(1),
+            },
+            () => {
+                return {
+                    ipAddress : "ip-updated",
+                };
+            }
+        ).then(() => {
+            t.fail("Should not succeed");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        t.deepEqual(handlerInvoked, 1);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 1);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-savepoint-rollback-to-savepoint.ts
@@ -1,0 +1,175 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.updateAndFetchZeroOrOneByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId: BigInt(1),
+                    },
+                    () => {
+                        return {
+                            ipAddress : "ip-updated",
+                        };
+                    }
+                );
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 0);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip-updated",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+
+                await connection.rollbackToSavepoint();
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 3);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 3);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-savepoint-rollback.ts
@@ -1,0 +1,175 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.updateAndFetchZeroOrOneByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId: BigInt(1),
+                    },
+                    () => {
+                        return {
+                            ipAddress : "ip-updated",
+                        };
+                    }
+                );
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 0);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip-updated",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+
+                await connection.rollback();
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 3);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 3);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-savepoint.ts
@@ -1,0 +1,145 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(rollbackInvoked, 0);
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.fail("Should not invoke rollback listener");
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await specialServerAppKeyTpt.updateAndFetchZeroOrOneByPrimaryKey(
+                    connection,
+                    {
+                        appKeyId: BigInt(1),
+                    },
+                    () => {
+                        return {
+                            ipAddress : "ip-updated",
+                        };
+                    }
+                );
+
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                t.deepEqual(rollbackInvoked, 0);
+
+                await specialServerAppKeyTpt.fetchOne(
+                    connection,
+                    () => tsql.eqPrimaryKey(
+                        specialServerAppKey,
+                        {
+                            appKeyId: BigInt(1),
+                        }
+                    )
+                ).then((result) => {
+                    t.deepEqual(
+                        result,
+                        {
+                            appKeyId: BigInt(1),
+                            appKeyTypeId: BigInt(1),
+                            ipAddress : "ip-updated",
+                            trustProxy : false,
+                            appId: BigInt(1),
+                            key: "server",
+                            createdAt: new Date(1),
+                            disabledAt: new Date(2),
+                        }
+                    );
+                });
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 3);
+        t.deepEqual(rollbackInvoked, 0);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip-updated",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-transaction-rollback.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-transaction-rollback.ts
@@ -1,0 +1,173 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.fail("Should not invoke commit listener");
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(commitInvoked, 0);
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await specialServerAppKeyTpt.updateAndFetchZeroOrOneByPrimaryKey(
+                connection,
+                {
+                    appKeyId: BigInt(1),
+                },
+                () => {
+                    return {
+                        ipAddress : "ip-updated",
+                    };
+                }
+            );
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 0);
+
+            await specialServerAppKeyTpt.fetchOne(
+                connection,
+                () => tsql.eqPrimaryKey(
+                    specialServerAppKey,
+                    {
+                        appKeyId: BigInt(1),
+                    }
+                )
+            ).then((result) => {
+                t.deepEqual(
+                    result,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip-updated",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+
+            await connection.rollback();
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 3);
+
+            await specialServerAppKeyTpt.fetchOne(
+                connection,
+                () => tsql.eqPrimaryKey(
+                    specialServerAppKey,
+                    {
+                        appKeyId: BigInt(1),
+                    }
+                )
+            ).then((result) => {
+                t.deepEqual(
+                    result,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 0);
+        t.deepEqual(rollbackInvoked, 3);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one-in-transaction.ts
@@ -1,0 +1,143 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(rollbackInvoked, 0);
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.fail("Should not invoke rollback listener");
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await connection.transaction(async (connection) => {
+            await specialServerAppKeyTpt.updateAndFetchZeroOrOneByPrimaryKey(
+                connection,
+                {
+                    appKeyId: BigInt(1),
+                },
+                () => {
+                    return {
+                        ipAddress : "ip-updated",
+                    };
+                }
+            );
+
+            t.deepEqual(handlerInvoked, 3);
+            t.deepEqual(commitInvoked, 0);
+            t.deepEqual(rollbackInvoked, 0);
+
+            await specialServerAppKeyTpt.fetchOne(
+                connection,
+                () => tsql.eqPrimaryKey(
+                    specialServerAppKey,
+                    {
+                        appKeyId: BigInt(1),
+                    }
+                )
+            ).then((result) => {
+                t.deepEqual(
+                    result,
+                    {
+                        appKeyId: BigInt(1),
+                        appKeyTypeId: BigInt(1),
+                        ipAddress : "ip-updated",
+                        trustProxy : false,
+                        appId: BigInt(1),
+                        key: "server",
+                        createdAt: new Date(1),
+                        disabledAt: new Date(2),
+                    }
+                );
+            });
+        });
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 3);
+        t.deepEqual(rollbackInvoked, 0);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip-updated",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one.ts
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch-zero-or-one/update-one.ts
@@ -1,0 +1,113 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onUpdateAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(rollbackInvoked, 0);
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.fail("Should not invoke rollback listener");
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.updateAndFetchZeroOrOneByPrimaryKey(
+            connection,
+            {
+                appKeyId: BigInt(1),
+            },
+            () => {
+                return {
+                    ipAddress : "ip-updated",
+                };
+            }
+        );
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 3);
+        t.deepEqual(rollbackInvoked, 0);
+
+        await specialServerAppKeyTpt.fetchOne(
+            connection,
+            () => tsql.eqPrimaryKey(
+                specialServerAppKey,
+                {
+                    appKeyId: BigInt(1),
+                }
+            )
+        ).then((result) => {
+            t.deepEqual(
+                result,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip-updated",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch/update-one.ts.todo
+++ b/test/run-time/input/connection/savepoint/table-per-type/update-and-fetch/update-one.ts.todo
@@ -1,0 +1,98 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../../dist";
+import {Pool} from "../../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../../sql-web-worker/worker.sql";
+import {createAppKeyTableSql, serverAppKeyTpt} from "../../../../design-pattern-table-per-type/app-key-example";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(createAppKeyTableSql);
+        await connection.rawQuery(`
+            CREATE TABLE specialServerAppKey (
+                appKeyId INTEGER NOT NULL,
+                FOREIGN KEY (appKeyId) REFERENCES serverAppKey (appKeyId)
+            );
+        `);
+
+        const specialServerAppKey = tsql.table("specialServerAppKey")
+            .addColumns({
+                appKeyId : tsql.dtBigIntSigned(),
+            })
+            .setId(columns => columns.appKeyId);
+        const specialServerAppKeyTpt = tsql.tablePerType(specialServerAppKey)
+            .addParent(serverAppKeyTpt);
+
+        let handlerInvoked = 0;
+        let commitInvoked = 0;
+        let rollbackInvoked = 0;
+        pool.onInsertAndFetch.addHandler(async (evt) => {
+            ++handlerInvoked;
+
+            evt.addOnCommitListener(() => {
+                t.deepEqual(handlerInvoked, 3);
+                t.deepEqual(rollbackInvoked, 0);
+                ++commitInvoked;
+            });
+
+            evt.addOnRollbackListener(() => {
+                t.fail("Should not invoke rollback listener");
+                ++rollbackInvoked;
+            });
+        });
+
+        await specialServerAppKeyTpt.insertAndFetch(
+            connection,
+            {
+                appId : BigInt(1),
+                key : "server",
+                createdAt : new Date(1),
+                disabledAt : new Date(2),
+                ipAddress : "ip",
+                trustProxy : false,
+            }
+        ).then((insertResult) => {
+            t.deepEqual(
+                insertResult,
+                {
+                    appKeyId: BigInt(1),
+                    appKeyTypeId: BigInt(1),
+                    ipAddress : "ip",
+                    trustProxy : false,
+                    appId: BigInt(1),
+                    key: "server",
+                    createdAt: new Date(1),
+                    disabledAt: new Date(2),
+                }
+            );
+        });
+
+        await specialServerAppKeyTpt.updateAndFetchOneByPrimaryKey(
+            connection,
+            {
+                appKeyId: BigInt(1),
+            },
+            () => {
+                return {
+                    ipAddress : "ip-updated",
+                };
+            }
+        );
+
+        t.deepEqual(handlerInvoked, 3);
+        t.deepEqual(commitInvoked, 3);
+        t.deepEqual(rollbackInvoked, 0);
+
+        await specialServerAppKey.existsByPrimaryKey(
+            connection,
+            {
+                appKeyId : BigInt(1),
+            }
+        ).then((result) => {
+            t.deepEqual(result, true);
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/fetch-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/fetch-more-than-one-in-savepoint.ts
@@ -1,0 +1,86 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testId,
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300),
+                (9,999);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testId : BigInt(9),
+                        };
+                    }
+                ).then(() => {
+                    t.fail("Should not update more than one row");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                                {
+                                    testId : BigInt(9),
+                                    testVal : BigInt(999),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/fetch-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/fetch-more-than-one-in-transaction.ts
@@ -1,0 +1,84 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testId,
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300),
+                (9,999);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateAndFetchOneByPrimaryKey(
+                connection,
+                {
+                    testId : BigInt(2),
+                },
+                () => {
+                    return {
+                        testId : BigInt(9),
+                    };
+                }
+            ).then(() => {
+                t.fail("Should not update more than one row");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                            {
+                                testId : BigInt(9),
+                                testVal : BigInt(999),
+                            },
+                        ]
+                    );
+                });
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/fetch-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/fetch-more-than-one.ts
@@ -1,0 +1,82 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testId,
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300),
+                (9,999);
+        `);
+
+        await dst.updateAndFetchOneByPrimaryKey(
+            connection,
+            {
+                testId : BigInt(2),
+            },
+            () => {
+                return {
+                    testId : BigInt(9),
+                };
+            }
+        ).then(() => {
+            t.fail("Should not update more than one row");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                        {
+                            testId : BigInt(9),
+                            testVal : BigInt(999),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/update-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/update-more-than-one-in-savepoint.ts
@@ -1,0 +1,115 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testVal : BigInt(999),
+                        };
+                    }
+                ).then(() => {
+                    t.fail("Should not update more than one row");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/update-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/update-more-than-one-in-transaction.ts
@@ -1,0 +1,113 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateAndFetchOneByPrimaryKey(
+                connection,
+                {
+                    testId : BigInt(2),
+                },
+                () => {
+                    return {
+                        testVal : BigInt(999),
+                    };
+                }
+            ).then(() => {
+                t.fail("Should not update more than one row");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/update-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/update-more-than-one.ts
@@ -1,0 +1,81 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (2,200),
+                (3,300);
+        `);
+
+        await dst.updateAndFetchOneByPrimaryKey(
+            connection,
+            {
+                testId : BigInt(2),
+            },
+            () => {
+                return {
+                    testVal : BigInt(999),
+                };
+            }
+        ).then(() => {
+            t.fail("Should not update more than one row");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-savepoint-rollback-to-savepoint.ts
@@ -1,0 +1,156 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollbackToSavepoint();
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-savepoint-rollback.ts
@@ -1,0 +1,156 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollback();
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-savepoint.ts
@@ -1,0 +1,102 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-transaction-rollback.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-transaction-rollback.ts
@@ -1,0 +1,128 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateAndFetchOneByPrimaryKey(
+                connection,
+                {
+                    testId : BigInt(2),
+                },
+                () => {
+                    return {
+                        testVal : BigInt(222),
+                    };
+                }
+            );
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(222),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+
+            await connection.rollback();
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one-in-transaction.ts
@@ -1,0 +1,100 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateAndFetchOneByPrimaryKey(
+                connection,
+                {
+                    testId : BigInt(2),
+                },
+                () => {
+                    return {
+                        testVal : BigInt(222),
+                    };
+                }
+            );
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(222),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-one/update-one.ts
@@ -1,0 +1,72 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await dst.updateAndFetchOneByPrimaryKey(
+            connection,
+            {
+                testId : BigInt(2),
+            },
+            () => {
+                return {
+                    testVal : BigInt(222),
+                };
+            }
+        );
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/fetch-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/fetch-more-than-one-in-savepoint.ts
@@ -1,0 +1,86 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testId,
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300),
+                (9,999);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchZeroOrOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testId : BigInt(9),
+                        };
+                    }
+                ).then(() => {
+                    t.fail("Should not update more than one row");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                                {
+                                    testId : BigInt(9),
+                                    testVal : BigInt(999),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/fetch-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/fetch-more-than-one-in-transaction.ts
@@ -1,0 +1,84 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testId,
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300),
+                (9,999);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateAndFetchZeroOrOneByPrimaryKey(
+                connection,
+                {
+                    testId : BigInt(2),
+                },
+                () => {
+                    return {
+                        testId : BigInt(9),
+                    };
+                }
+            ).then(() => {
+                t.fail("Should not update more than one row");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                            {
+                                testId : BigInt(9),
+                                testVal : BigInt(999),
+                            },
+                        ]
+                    );
+                });
+        });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/fetch-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/fetch-more-than-one.ts
@@ -1,0 +1,82 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testId,
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300),
+                (9,999);
+        `);
+
+        await dst.updateAndFetchZeroOrOneByPrimaryKey(
+            connection,
+            {
+                testId : BigInt(2),
+            },
+            () => {
+                return {
+                    testId : BigInt(9),
+                };
+            }
+        ).then(() => {
+            t.fail("Should not update more than one row");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                        {
+                            testId : BigInt(9),
+                            testVal : BigInt(999),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-more-than-one-in-savepoint.ts
@@ -1,0 +1,115 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchZeroOrOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testVal : BigInt(999),
+                        };
+                    }
+                ).then(() => {
+                    t.fail("Should not update more than one row");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-more-than-one-in-transaction.ts
@@ -1,0 +1,113 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateAndFetchZeroOrOneByPrimaryKey(
+                connection,
+                {
+                    testId : BigInt(2),
+                },
+                () => {
+                    return {
+                        testVal : BigInt(999),
+                    };
+                }
+            ).then(() => {
+                t.fail("Should not update more than one row");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-more-than-one.ts
@@ -1,0 +1,81 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (2,200),
+                (3,300);
+        `);
+
+        await dst.updateAndFetchZeroOrOneByPrimaryKey(
+            connection,
+            {
+                testId : BigInt(2),
+            },
+            () => {
+                return {
+                    testVal : BigInt(999),
+                };
+            }
+        ).then(() => {
+            t.fail("Should not update more than one row");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-savepoint-rollback-to-savepoint.ts
@@ -1,0 +1,156 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchZeroOrOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollbackToSavepoint();
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-savepoint-rollback.ts
@@ -1,0 +1,156 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchZeroOrOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollback();
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-savepoint.ts
@@ -1,0 +1,102 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateAndFetchZeroOrOneByPrimaryKey(
+                    connection,
+                    {
+                        testId : BigInt(2),
+                    },
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-transaction-rollback.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-transaction-rollback.ts
@@ -1,0 +1,128 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateAndFetchZeroOrOneByPrimaryKey(
+                connection,
+                {
+                    testId : BigInt(2),
+                },
+                () => {
+                    return {
+                        testVal : BigInt(222),
+                    };
+                }
+            );
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(222),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+
+            await connection.rollback();
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one-in-transaction.ts
@@ -1,0 +1,100 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateAndFetchZeroOrOneByPrimaryKey(
+                connection,
+                {
+                    testId : BigInt(2),
+                },
+                () => {
+                    return {
+                        testVal : BigInt(222),
+                    };
+                }
+            );
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(222),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one.ts
+++ b/test/run-time/input/connection/savepoint/update-and-fetch-zero-or-one/update-one.ts
@@ -1,0 +1,72 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await dst.updateAndFetchZeroOrOneByPrimaryKey(
+            connection,
+            {
+                testId : BigInt(2),
+            },
+            () => {
+                return {
+                    testVal : BigInt(222),
+                };
+            }
+        );
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-one/update-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-one/update-more-than-one-in-savepoint.ts
@@ -1,0 +1,107 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateOne(
+                    connection,
+                    columns => tsql.gtEq(
+                        columns.testVal,
+                        BigInt(200)
+                    ),
+                    () => {
+                        return {
+                            testVal : BigInt(999),
+                        };
+                    }
+                ).then(() => {
+                    t.fail("Should not update more than one row");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-one/update-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-one/update-more-than-one-in-transaction.ts
@@ -1,0 +1,105 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateOne(
+                connection,
+                columns => tsql.gtEq(
+                    columns.testVal,
+                    BigInt(200)
+                ),
+                () => {
+                    return {
+                        testVal : BigInt(999),
+                    };
+                }
+            ).then(() => {
+                t.fail("Should not update more than one row");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-one/update-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/update-one/update-more-than-one.ts
@@ -1,0 +1,77 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await dst.updateOne(
+            connection,
+            columns => tsql.gtEq(
+                columns.testVal,
+                BigInt(200)
+            ),
+            () => {
+                return {
+                    testVal : BigInt(999),
+                };
+            }
+        ).then(() => {
+            t.fail("Should not update more than one row");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-one/update-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-one/update-one-in-savepoint-rollback-to-savepoint.ts
@@ -1,0 +1,157 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateOne(
+                    connection,
+                    columns => tsql.eq(
+                        columns.testVal,
+                        BigInt(200)
+                    ),
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollbackToSavepoint();
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-one/update-one-in-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/update-one/update-one-in-savepoint-rollback.ts
@@ -1,0 +1,157 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateOne(
+                    connection,
+                    columns => tsql.eq(
+                        columns.testVal,
+                        BigInt(200)
+                    ),
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollback();
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-one/update-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-one/update-one-in-savepoint.ts
@@ -1,0 +1,103 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateOne(
+                    connection,
+                    columns => tsql.eq(
+                        columns.testVal,
+                        BigInt(200)
+                    ),
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-one/update-one-in-transaction-rollback.ts
+++ b/test/run-time/input/connection/savepoint/update-one/update-one-in-transaction-rollback.ts
@@ -1,0 +1,129 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateOne(
+                connection,
+                columns => tsql.eq(
+                    columns.testVal,
+                    BigInt(200)
+                ),
+                () => {
+                    return {
+                        testVal : BigInt(222),
+                    };
+                }
+            );
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(222),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+
+            await connection.rollback();
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-one/update-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-one/update-one-in-transaction.ts
@@ -1,0 +1,101 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateOne(
+                connection,
+                columns => tsql.eq(
+                    columns.testVal,
+                    BigInt(200)
+                ),
+                () => {
+                    return {
+                        testVal : BigInt(222),
+                    };
+                }
+            );
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(222),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-one/update-one.ts
+++ b/test/run-time/input/connection/savepoint/update-one/update-one.ts
@@ -1,0 +1,73 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await dst.updateOne(
+            connection,
+            columns => tsql.eq(
+                columns.testVal,
+                BigInt(200)
+            ),
+            () => {
+                return {
+                    testVal : BigInt(222),
+                };
+            }
+        );
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-zero-or-one/update-more-than-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-zero-or-one/update-more-than-one-in-savepoint.ts
@@ -1,0 +1,107 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateZeroOrOne(
+                    connection,
+                    columns => tsql.gtEq(
+                        columns.testVal,
+                        BigInt(200)
+                    ),
+                    () => {
+                        return {
+                            testVal : BigInt(999),
+                        };
+                    }
+                ).then(() => {
+                    t.fail("Should not update more than one row");
+                }).catch((err) => {
+                    t.true(err instanceof tsql.TooManyRowsFoundError);
+                });
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-zero-or-one/update-more-than-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-zero-or-one/update-more-than-one-in-transaction.ts
@@ -1,0 +1,105 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateZeroOrOne(
+                connection,
+                columns => tsql.gtEq(
+                    columns.testVal,
+                    BigInt(200)
+                ),
+                () => {
+                    return {
+                        testVal : BigInt(999),
+                    };
+                }
+            ).then(() => {
+                t.fail("Should not update more than one row");
+            }).catch((err) => {
+                t.true(err instanceof tsql.TooManyRowsFoundError);
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-zero-or-one/update-more-than-one.ts
+++ b/test/run-time/input/connection/savepoint/update-zero-or-one/update-more-than-one.ts
@@ -1,0 +1,77 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await dst.updateZeroOrOne(
+            connection,
+            columns => tsql.gtEq(
+                columns.testVal,
+                BigInt(200)
+            ),
+            () => {
+                return {
+                    testVal : BigInt(999),
+                };
+            }
+        ).then(() => {
+            t.fail("Should not update more than one row");
+        }).catch((err) => {
+            t.true(err instanceof tsql.TooManyRowsFoundError);
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-savepoint-rollback-to-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-savepoint-rollback-to-savepoint.ts
@@ -1,0 +1,157 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateZeroOrOne(
+                    connection,
+                    columns => tsql.eq(
+                        columns.testVal,
+                        BigInt(200)
+                    ),
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollbackToSavepoint();
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-savepoint-rollback.ts
+++ b/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-savepoint-rollback.ts
@@ -1,0 +1,157 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateZeroOrOne(
+                    connection,
+                    columns => tsql.eq(
+                        columns.testVal,
+                        BigInt(200)
+                    ),
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+
+                await connection.rollback();
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(200),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-savepoint.ts
+++ b/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-savepoint.ts
@@ -1,0 +1,103 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await connection.savepoint(async (connection) => {
+                await dst.updateZeroOrOne(
+                    connection,
+                    columns => tsql.eq(
+                        columns.testVal,
+                        BigInt(200)
+                    ),
+                    () => {
+                        return {
+                            testVal : BigInt(222),
+                        };
+                    }
+                );
+
+                await tsql.from(dst)
+                    .select(columns => [columns])
+                    .orderBy(columns => [
+                        columns.testId.asc(),
+                    ])
+                    .fetchAll(connection)
+                    .then((rows) => {
+                        t.deepEqual(
+                            rows,
+                            [
+                                {
+                                    testId : BigInt(1),
+                                    testVal : BigInt(100),
+                                },
+                                {
+                                    testId : BigInt(2),
+                                    testVal : BigInt(222),
+                                },
+                                {
+                                    testId : BigInt(3),
+                                    testVal : BigInt(300),
+                                },
+                            ]
+                        );
+                    });
+            });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-transaction-rollback.ts
+++ b/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-transaction-rollback.ts
@@ -1,0 +1,129 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateZeroOrOne(
+                connection,
+                columns => tsql.eq(
+                    columns.testVal,
+                    BigInt(200)
+                ),
+                () => {
+                    return {
+                        testVal : BigInt(222),
+                    };
+                }
+            );
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(222),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+
+            await connection.rollback();
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(200),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(200),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-transaction.ts
+++ b/test/run-time/input/connection/savepoint/update-zero-or-one/update-one-in-transaction.ts
@@ -1,0 +1,101 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await connection.transaction(async (connection) => {
+            await dst.updateZeroOrOne(
+                connection,
+                columns => tsql.eq(
+                    columns.testVal,
+                    BigInt(200)
+                ),
+                () => {
+                    return {
+                        testVal : BigInt(222),
+                    };
+                }
+            );
+
+            await tsql.from(dst)
+                .select(columns => [columns])
+                .orderBy(columns => [
+                    columns.testId.asc(),
+                ])
+                .fetchAll(connection)
+                .then((rows) => {
+                    t.deepEqual(
+                        rows,
+                        [
+                            {
+                                testId : BigInt(1),
+                                testVal : BigInt(100),
+                            },
+                            {
+                                testId : BigInt(2),
+                                testVal : BigInt(222),
+                            },
+                            {
+                                testId : BigInt(3),
+                                testVal : BigInt(300),
+                            },
+                        ]
+                    );
+                });
+        });
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/run-time/input/connection/savepoint/update-zero-or-one/update-one.ts
+++ b/test/run-time/input/connection/savepoint/update-zero-or-one/update-one.ts
@@ -1,0 +1,73 @@
+import * as tape from "tape";
+import * as tsql from "../../../../../../dist";
+import {Pool} from "../../../sql-web-worker/promise.sql";
+import {SqliteWorker} from "../../../sql-web-worker/worker.sql";
+
+tape(__filename, async (t) => {
+    const pool = new Pool(new SqliteWorker());
+
+    const dst = tsql.table("dst")
+        .addColumns({
+            testId : tsql.dtBigIntSigned(),
+            testVal : tsql.dtBigIntSigned(),
+        })
+        .setPrimaryKey(columns => [columns.testId])
+        .addMutable(columns => [
+            columns.testVal,
+        ]);
+
+    await pool.acquire(async (connection) => {
+        await connection.rawQuery(`
+            CREATE TABLE dst (
+                testId INT PRIMARY KEY,
+                testVal INT
+            );
+
+            INSERT INTO dst(testId, testVal) VALUES
+                (1,100),
+                (2,200),
+                (3,300);
+        `);
+
+        await dst.updateZeroOrOne(
+            connection,
+            columns => tsql.eq(
+                columns.testVal,
+                BigInt(200)
+            ),
+            () => {
+                return {
+                    testVal : BigInt(222),
+                };
+            }
+        );
+
+        await tsql.from(dst)
+            .select(columns => [columns])
+            .orderBy(columns => [
+                columns.testId.asc(),
+            ])
+            .fetchAll(connection)
+            .then((rows) => {
+                t.deepEqual(
+                    rows,
+                    [
+                        {
+                            testId : BigInt(1),
+                            testVal : BigInt(100),
+                        },
+                        {
+                            testId : BigInt(2),
+                            testVal : BigInt(222),
+                        },
+                        {
+                            testId : BigInt(3),
+                            testVal : BigInt(300),
+                        },
+                    ]
+                );
+            });
+    });
+
+    t.end();
+});

--- a/test/sqlite-sqlfier.ts
+++ b/test/sqlite-sqlfier.ts
@@ -580,6 +580,8 @@ export const sqliteSqlfier : Sqlfier = {
         [OperatorType.NULL_SAFE_EQUAL] : ({operands}) => insertBetween(operands, "IS"),
         [OperatorType.LESS_THAN] : ({operands}) => insertBetween(operands, "<"),
         [OperatorType.GREATER_THAN] : ({operands}) => insertBetween(operands, ">"),
+        [OperatorType.LESS_THAN_OR_EQUAL] : ({operands}) => insertBetween(operands, "<="),
+        [OperatorType.GREATER_THAN_OR_EQUAL] : ({operands}) => insertBetween(operands, ">="),
         [OperatorType.IN] : ({operands : [x, y, ...rest]}) => {
             if (rest.length == 0 && Parentheses.IsParentheses(y) && QueryBaseUtil.isQuery(y.ast)) {
                 return [


### PR DESCRIPTION
A bunch of operations imply an **atomic** nature.
And they were atomic, as long as you invoked them outside of a transaction.

However, invoking them inside of a transaction made these operations no longer atomic.
You could have,
```ts
transaction {
  try {
    deleteOne();
  } catch (err) {
    commit();
  }
}
```

`deleteOne()` throws an error if more than one row is deleted. But if you catch the error and commit, it'll actually commit the fact that it deleted more than one row.

With savepoints, and nesting savepoints, the above snippet commits no changes. Because `deleteOne()` now uses savepoints internally to be atomic, even inside transactions and other savepoints.